### PR TITLE
disable autocomplete and fix no command help

### DIFF
--- a/ragna/_cli/main.py
+++ b/ragna/_cli/main.py
@@ -13,7 +13,12 @@ from .list_requirements import make_requirements_tables
 
 __all__ = ["app"]
 
-app = typer.Typer(name="ragna", no_args_is_help=True)
+app = typer.Typer(
+    name="ragna",
+    invoke_without_command=True,
+    no_args_is_help=True,
+    add_completion=False,
+)
 console = Console()
 
 

--- a/ragna/extensions/__init__.py
+++ b/ragna/extensions/__init__.py
@@ -18,7 +18,7 @@ hookimpl = pluggy.HookimplMarker("ragna")
 del pluggy
 
 
-from ._demo import ragna_demo_llm, ragna_demo_source_stragnage
+from ._demo import ragna_demo_llm, ragna_demo_source_storage
 from .llm import (
     anthropic_claude_1_instant_llm,
     anthropic_claude_2_llm,


### PR DESCRIPTION
1. autocompletion needs to be installed and my guess is that users won't invoke the "binary" that often. Happy to reconsider if my assumption is false.
2. I thought setting `no_args_is_help=True` is sufficient to do what it says on the tin. But apparently we also need `invoke_without_command=True`.