### PR TITLE
implement PDF page extractor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 extensions = [
     'chromadb>=0.4',
+    'pymupdf',
     'requests',
     'tiktoken',
 ]

--- a/ragna/_backend/document.py
+++ b/ragna/_backend/document.py
@@ -32,7 +32,7 @@ class PageExtractor(Component, abc.ABC):
             return suffix in self.SUFFIX
 
     @abc.abstractmethod
-    def extract_pages(self, content: bytes) -> Iterator[Page]:
+    def extract_pages(self, name: str, content: bytes) -> Iterator[Page]:
         ...
 
 
@@ -87,4 +87,4 @@ class Document:
         return self.metadata.id
 
     def extract_pages(self) -> Iterator[Page]:
-        yield from self.page_extractor.extract_pages(self.content)
+        yield from self.page_extractor.extract_pages(self.name, self.content)

--- a/ragna/extensions/__init__.py
+++ b/ragna/extensions/__init__.py
@@ -33,5 +33,10 @@ from .llm import (
     OpenaiGpt35Turbo16kLlm,
     OpenaiGpt4Llm,
 )
-from .page_extractor import txt_page_extractor, TxtPageExtractor
+from .page_extractor import (
+    pdf_page_extractor,
+    PdfPageExtractor,
+    txt_page_extractor,
+    TxtPageExtractor,
+)
 from .source_storage import chroma_source_storage, ChromaSourceStorage

--- a/ragna/extensions/page_extractor/__init__.py
+++ b/ragna/extensions/page_extractor/__init__.py
@@ -1,1 +1,2 @@
+from ._pdf import pdf_page_extractor, PdfPageExtractor
 from ._txt import txt_page_extractor, TxtPageExtractor

--- a/ragna/extensions/page_extractor/_pdf.py
+++ b/ragna/extensions/page_extractor/_pdf.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+from typing import Iterator
+
+from ragna.extensions import (
+    hookimpl,
+    PackageRequirement,
+    Page,
+    PageExtractor,
+    Requirement,
+)
+
+
+class PdfPageExtractor(PageExtractor):
+    @classmethod
+    def requirements(cls) -> list[Requirement]:
+        return [PackageRequirement("pymupdf")]
+
+    # TODO: pymupdf supports a lot more formats. Check if it is useful to expose them
+    #  here
+    SUFFIX = ".pdf"
+
+    def extract_pages(self, name: str, content: bytes) -> Iterator[Page]:
+        import fitz
+
+        with fitz.Document(stream=content, filetype=Path(name).suffix) as document:
+            for number, page in enumerate(document, 1):
+                yield Page(text=page.get_text(sort=True), number=number)
+
+
+@hookimpl(specname="ragna_page_extractor")
+def pdf_page_extractor():
+    return PdfPageExtractor

--- a/ragna/extensions/page_extractor/_txt.py
+++ b/ragna/extensions/page_extractor/_txt.py
@@ -6,7 +6,7 @@ from ragna.extensions import hookimpl, Page, PageExtractor
 class TxtPageExtractor(PageExtractor):
     SUFFIX = ".txt"
 
-    def extract_pages(self, content: bytes) -> Iterator[Page]:
+    def extract_pages(self, name: str, content: bytes) -> Iterator[Page]:
         yield Page(content.decode())
 
 


### PR DESCRIPTION
We are using [PyMuPdf](https://github.com/pymupdf/PyMuPDF) as backend. It has a really simple interface for what we want to do. Plus, according to their own [benchmarks](https://pymupdf.readthedocs.io/en/latest/about.html#performance) it is the fastest available option.

I needed to add two fixes to enable this:

1. `PageExtractor.extract_pages` also needs the the document name to infer the file type from it in the regular case.
2. Although one does `pip install pymupdf`, the python module is called `fitz`. Due to this disconnect, I needed to refactor the availability check for `PackageRequirement`