### PR TITLE
depend on currently unreleased panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # Ragna
+
+## `panel`
+
+The main component in the UI is the chat box. It will get a significant revamp in `panel==1.3`. However, until that is released, we need to install from source and in particular from the [`chat_components` branch](https://github.com/holoviz/panel/tree/chat_components). Fortunately, `panel` contains no compiled parts and thus it is as easy as
+
+```
+pip install git+https://github.com/holoviz/panel@chat_components
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,9 @@ dependencies = [
     "typer",
     "rich",
     "pluggy",
-    "panel >=1.2, <1.3",
+    # TODO: this needs to be constrained to panel >=1.3 as soon as that is released.
+    #  See README.md#panel for details
+    "panel",
     "packaging",
     "param",
     "importlib_metadata >=4.6; python_version < '3.10'",


### PR DESCRIPTION
cc @leej3 Simplifies the instructions in #9. We don't need the full panel dev environment, but only their unreleased version.