### PR TITLE
add black as formatter for notebooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,10 @@ repos:
         additional_dependencies:
           - black == 23.7.0
           - usort == 1.0.7
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black-jupyter
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.0.284
     hooks:


### PR DESCRIPTION
We are likely going to have a lot more example notebooks that we have right now. This makes sure they are properly formatted.