### PR TITLE
use cloudpickle over pickle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
+    "cloudpickle",
     "huey",
     "importlib_metadata >=4.6; python_version < '3.10'",
     "packaging",

--- a/ragna/core/_queue.py
+++ b/ragna/core/_queue.py
@@ -1,8 +1,9 @@
 import contextlib
 import io
-import pickle
 from typing import Optional
 from urllib.parse import urlsplit
+
+import cloudpickle
 
 import huey.api
 import huey.utils
@@ -13,7 +14,7 @@ from ._requirement import PackageRequirement
 
 
 def execute(serialized_fn):
-    fn = pickle.loads(serialized_fn)
+    fn = cloudpickle.loads(serialized_fn)
 
     # FIXME: this will only surfaces the output in case the job succeeds. While
     #  better than nothing, surfacing output in the failure cases is more important
@@ -60,7 +61,7 @@ class Queue:
         huey.api.TaskWrapper(self._huey, execute, name=_Task.__name__)
 
     async def enqueue(self, fn, **task_kwargs):
-        task = _Task(args=(pickle.dumps(fn),), **task_kwargs)
+        task = _Task(args=(cloudpickle.dumps(fn),), **task_kwargs)
         result = self._huey.enqueue(task)
         output = await aget_result(result)
         if isinstance(output, huey.utils.Error):


### PR DESCRIPTION
We initially had that, but it was removed in #37, because I thought we didn't need it any longer. However, the following error pops up if you start `ragna api` externally and run the REST API example notebook (commenting out the subprocess):

```
TypeError: cannot pickle '_io.TextIOWrapper' object
```

So far I was unable to reproduce it outside this setup, but I'm certain the logger is the issue. Putting `return None` at the top of

https://github.com/Quansight/ragna/blob/2e0e98bac7b0a83794118f689a87507efb056438/ragna/core/_config.py#L111-L112

resolves the issue. One more argument for #42 TBH.

Anyway, in favor of velocity, I'm reinstating `cloudpickle` to circumvent the issue for now.