### PR TITLE
add timestamp to message

### DIFF
--- a/ragna/_api.py
+++ b/ragna/_api.py
@@ -1,3 +1,4 @@
+import datetime
 import functools
 from typing import Annotated
 from uuid import UUID
@@ -43,6 +44,7 @@ class MessageModel(BaseModel):
     role: MessageRole
     content: str
     sources: list[SourceModel]
+    timestamp: datetime.datetime
 
     @classmethod
     def from_message(cls, message):
@@ -51,6 +53,7 @@ class MessageModel(BaseModel):
             role=message.role,
             content=message.content,
             sources=[SourceModel.from_source(s) for s in message.sources],
+            timestamp=message.timestamp,
         )
 
 

--- a/ragna/core/_assistant.py
+++ b/ragna/core/_assistant.py
@@ -1,5 +1,5 @@
 import abc
-
+import datetime
 import enum
 
 from typing import Optional
@@ -28,6 +28,7 @@ class Message:
         self.content = content
         self.role = role
         self.sources = sources or []
+        self.timestamp = datetime.datetime.utcnow()
 
     def __repr__(self):
         return self.content

--- a/ragna/core/_orm.py
+++ b/ragna/core/_orm.py
@@ -117,3 +117,4 @@ class MessageState(Base):
         secondary=source_message_state_association_table,
         back_populates="message_states",
     )
+    timestamp = Column(types.DateTime)

--- a/ragna/core/_rag.py
+++ b/ragna/core/_rag.py
@@ -340,12 +340,9 @@ class Chat:
     def _append_message(self, message: Message):
         self.messages.append(message)
         self._state.add_message(
+            message,
             user=self._user,
             chat_id=self.id,
-            id=message.id,
-            content=message.content,
-            role=message.role,
-            sources=message.sources,
         )
 
     class _SpecialChatParams(BaseModel):


### PR DESCRIPTION
As per suggestion of @pierrotsmnrd. Each message now has a timestamp that we can display in the UI. This changes the DB scheme. Meaning, `rm ~/.cache/ragna/ragna.db` if you work with a persistent state.