### PR TITLE
add proper error message to ragna worker with inmemory queue

### DIFF
--- a/ragna/_cli.py
+++ b/ragna/_cli.py
@@ -122,6 +122,10 @@ def worker(
     config: ConfigAnnotated = "ragna.demo_config",
     num_workers: Annotated[int, typer.Option("--num-workers", "-n")] = 1,
 ):
+    if config.queue_database_url == "memory":
+        print(f"With {config.queue_database_url=} no worker is required!")
+        raise typer.Exit(1)
+
     queue = Queue(config, load_components=True)
     worker = queue.create_worker(num_workers)
 


### PR DESCRIPTION
This is awkward with

https://github.com/Quansight/ragna/blob/9a4e3746a479a44ebf6de2e55fa6a60dfaa2009f/ragna/_cli.py#L119-L122

but this will be fixed by my next larger PR that refactors CLI and configs in general.