### PR TITLE
use prettier as markdown / yaml / toml formatter

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -37,7 +37,10 @@ runs:
       uses: actions/cache@v3
       with:
         path: ${{ env.CONDA }}/envs
-        key: env-${{ runner.os }}-${{ runner.arch }}-${{ inputs.python-version }}|${{steps.cache-key.outputs.date }}-${{ hashFiles('environment-dev.yml', 'pyproject.toml') }}
+        key:
+          env-${{ runner.os }}-${{ runner.arch }}-${{ inputs.python-version
+          }}|${{steps.cache-key.outputs.date }}-${{ hashFiles('environment-dev.yml',
+          'pyproject.toml') }}
         restore-keys: |
           env-${{ runner.os }}-${{ runner.arch }}-${{ inputs.python-version }}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,17 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
-      - id: check-toml
-      - id: check-yaml
       - id: mixed-line-ending
-        args: [ --fix=lf ]
-        exclude: docs/make.bat
+        args: [--fix=lf]
       - id: end-of-file-fixer
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.0.3
+    hooks:
+      - id: prettier
+        types_or:
+          - markdown
+          - toml
+          - yaml
   - repo: https://github.com/omnilib/ufmt
     rev: v2.1.0
     hooks:

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,2 @@
+proseWrap: always
+printWidth: 88

--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@
 
 <hr>
 
-> **Note**
-> This project is in active development,
-> check back after 26th October for updates!
+> **Note** This project is in active development, check back after 26th October for
+> updates!
 
 A RAG orchestration framework. ⛵️
 
 ## Local development
 
-* Quickstart: [docs/get-started.md](docs/get-started.md#minimal-example)
-* Setup: [docs/community/contribute.md](docs/community/contribute.md)
+- Quickstart: [docs/get-started.md](docs/get-started.md#minimal-example)
+- Setup: [docs/community/contribute.md](docs/community/contribute.md)
 
 ## Code of Conduct
 
-This repository is governed by the [Quansight Repository Code of Conduct](https://github.com/Quansight/.github/blob/master/CODE_OF_CONDUCT.md).
+This repository is governed by the
+[Quansight Repository Code of Conduct](https://github.com/Quansight/.github/blob/master/CODE_OF_CONDUCT.md).

--- a/docs/community/contribute.md
+++ b/docs/community/contribute.md
@@ -36,11 +36,11 @@ ragna ls
 
 Ragna uses MkDocs to build it's documentation.
 
-You can contribute to narrative documentation at `docs/`,
-and configure the docs website using `mkdocs.yml`
+You can contribute to narrative documentation at `docs/`, and configure the docs website
+using `mkdocs.yml`
 
-To start a development build that auto-refreshes on new changes,
-run the following from the root directory:
+To start a development build that auto-refreshes on new changes, run the following from
+the root directory:
 
 ```bash
 mkdocs serve

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -4,7 +4,6 @@
 
 <!-- TODO -->
 
-
 ## Minimal example
 
 ```python

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,9 +6,10 @@ title: Welcome
 
 A toolkit for building RAG-based LLM applications, it provides:
 
-* **Python API** for RAG orchestration
-* **REST API** for building web applications
-* **Ready-to-use web application** with UI for uploading documents, selecting models, and chat interface.
+- **Python API** for RAG orchestration
+- **REST API** for building web applications
+- **Ready-to-use web application** with UI for uploading documents, selecting models,
+  and chat interface.
 
 <!-- TODO:
 - Update description

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -8,16 +8,16 @@ dependencies:
   #  - redis-server
   - pip
   - pip:
-    - jupyter
-    - python-dotenv
-    - boto3
-    - pytest >=6
-    - mypy ==1.6.1
-    - pre-commit
-    - types-aiofiles
-    - sqlalchemy-stubs
-    # documentation
-    - mkdocs
-    - mkdocs-material
-    - mkdocstrings[python]
-    - mkdocs-gen-files
+      - jupyter
+      - python-dotenv
+      - boto3
+      - pytest >=6
+      - mypy ==1.6.1
+      - pre-commit
+      - types-aiofiles
+      - sqlalchemy-stubs
+      # documentation
+      - mkdocs
+      - mkdocs-material
+      - mkdocstrings[python]
+      - mkdocs-gen-files


### PR DESCRIPTION
If possible, I want to merge this before #100 to avoid too much noise afterwards. We can use the same hook to also format `.js` / `.css` / `.html` files that will be part of the repo after #61.