### PR TITLE
return JSON schema of available components

### DIFF
--- a/ragna/_api/core.py
+++ b/ragna/_api/core.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Annotated, cast, Iterator
+from typing import Annotated, Any, cast, Iterator, Type
 
 import aiofiles
 
@@ -9,6 +9,8 @@ from fastapi.responses import JSONResponse
 import ragna
 import ragna.core
 from ragna.core import Config, Rag, RagnaException
+from ragna.core._components import Component
+from ragna.core._rag import SpecialChatParams
 
 from . import database, schemas
 
@@ -45,15 +47,32 @@ def app(config: Config) -> FastAPI:
 
     UserDependency = Annotated[str, Depends(authentication.get_user)]
 
+    def _get_component_json_schema(
+        component: Type[Component],
+    ) -> dict[str, dict[str, Any]]:
+        json_schema = component._protocol_model().model_json_schema()
+        # FIXME: there is likely a better way to exclude certain fields builtin in
+        #  pydantic
+        for special_param in SpecialChatParams.model_fields:
+            if (
+                "properties" in json_schema
+                and special_param in json_schema["properties"]
+            ):
+                del json_schema["properties"][special_param]
+            if "required" in json_schema and special_param in json_schema["required"]:
+                json_schema["required"].remove(special_param)
+        return json_schema
+
     @app.get("/components")
     async def get_components(_: UserDependency) -> schemas.Components:
         return schemas.Components(
             source_storages=[
-                source_storage.display_name()
+                _get_component_json_schema(source_storage)
                 for source_storage in config.core.source_storages
             ],
             assistants=[
-                assistant.display_name() for assistant in config.core.assistants
+                _get_component_json_schema(assistant)
+                for assistant in config.core.assistants
             ],
         )
 

--- a/ragna/_api/core.py
+++ b/ragna/_api/core.py
@@ -66,6 +66,7 @@ def app(config: Config) -> FastAPI:
     @app.get("/components")
     async def get_components(_: UserDependency) -> schemas.Components:
         return schemas.Components(
+            documents=sorted(config.core.document.supported_suffixes()),
             source_storages=[
                 _get_component_json_schema(source_storage)
                 for source_storage in config.core.source_storages

--- a/ragna/_api/schemas.py
+++ b/ragna/_api/schemas.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 import uuid
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -9,8 +10,8 @@ import ragna.core
 
 
 class Components(BaseModel):
-    source_storages: list[str]
-    assistants: list[str]
+    source_storages: list[dict[str, Any]]
+    assistants: list[dict[str, Any]]
 
 
 class Document(BaseModel):

--- a/ragna/_api/schemas.py
+++ b/ragna/_api/schemas.py
@@ -10,6 +10,7 @@ import ragna.core
 
 
 class Components(BaseModel):
+    documents: list[str]
     source_storages: list[dict[str, Any]]
     assistants: list[dict[str, Any]]
 

--- a/ragna/core/_components.py
+++ b/ragna/core/_components.py
@@ -10,7 +10,7 @@ import pydantic
 import pydantic.utils
 
 from ._document import Document
-from ._utils import RequirementsMixin
+from ._utils import merge_models, RequirementsMixin
 
 if TYPE_CHECKING:
     from ._config import Config
@@ -33,7 +33,9 @@ class Component(RequirementsMixin):
 
     @classmethod
     @functools.cache
-    def _models(cls) -> dict[tuple[Type[Component], str], Type[pydantic.BaseModel]]:
+    def _protocol_models(
+        cls,
+    ) -> dict[tuple[Type[Component], str], Type[pydantic.BaseModel]]:
         protocol_cls, protocol_methods = next(
             (cls_, cls_.__ragna_protocol_methods__)  # type: ignore[attr-defined]
             for cls_ in cls.__mro__
@@ -61,6 +63,11 @@ class Component(RequirementsMixin):
                 },
             )
         return models
+
+    @classmethod
+    @functools.cache
+    def _protocol_model(cls) -> Type[pydantic.BaseModel]:
+        return merge_models(cls.display_name(), *cls._protocol_models().values())
 
 
 class Source(pydantic.BaseModel):

--- a/ragna/core/_rag.py
+++ b/ragna/core/_rag.py
@@ -200,7 +200,7 @@ class Chat:
             *assistant_models.values(),
         )
 
-        chat_params = ChatModel.model_validate(**params).model_dump(exclude_none=True)
+        chat_params = ChatModel.model_validate(params).model_dump(exclude_none=True)
         return {
             component_and_action: model(**chat_params).model_dump()
             for component_and_action, model in itertools.chain(

--- a/ragna/core/_rag.py
+++ b/ragna/core/_rag.py
@@ -3,17 +3,15 @@ from __future__ import annotations
 import datetime
 import itertools
 import uuid
-from collections import defaultdict
-from typing import Any, cast, Iterable, Optional, Type, TypeVar, Union
+from typing import Any, Iterable, Optional, Type, TypeVar, Union
 
-import pydantic
-from pydantic import BaseModel, ConfigDict, create_model, Field
+from pydantic import BaseModel, Field
 
 from ._components import Assistant, Component, Message, MessageRole, SourceStorage
 from ._config import Config
 from ._document import Document
 from ._queue import Queue
-from ._utils import default_user, RagnaException
+from ._utils import default_user, merge_models, RagnaException
 
 T = TypeVar("T", bound=Component)
 
@@ -46,7 +44,7 @@ class Rag:
         )
 
 
-class _SpecialChatParams(BaseModel):
+class SpecialChatParams(BaseModel):
     user: str = Field(default_factory=default_user)
     chat_id: uuid.UUID = Field(default_factory=uuid.uuid4)
     chat_name: str = Field(
@@ -94,7 +92,7 @@ class Chat:
         self.source_storage = self._rag._queue.parse_component(source_storage)
         self.assistant = self._rag._queue.parse_component(assistant)
 
-        special_params = _SpecialChatParams().model_dump()
+        special_params = SpecialChatParams().model_dump()
 
         special_params.update(params)
         params = special_params
@@ -192,54 +190,23 @@ class Chat:
     def _unpack_chat_params(
         self, params: dict[str, Any]
     ) -> dict[tuple[Type[Component], str], dict[str, Any]]:
-        source_storage_models = self.source_storage._models()
-        assistant_models = self.assistant._models()
+        source_storage_models = self.source_storage._protocol_models()
+        assistant_models = self.assistant._protocol_models()
 
-        ChatModel = self._merge_models(
-            _SpecialChatParams,
+        ChatModel = merge_models(
+            str(self.params["chat_id"]),
+            SpecialChatParams,
             *source_storage_models.values(),
             *assistant_models.values(),
         )
 
-        chat_params = ChatModel(**params).model_dump(exclude_none=True)
+        chat_params = ChatModel.model_validate(**params).model_dump(exclude_none=True)
         return {
             component_and_action: model(**chat_params).model_dump()
             for component_and_action, model in itertools.chain(
                 source_storage_models.items(), assistant_models.items()
             )
         }
-
-    def _merge_models(
-        self, *models: Type[pydantic.BaseModel]
-    ) -> Type[pydantic.BaseModel]:
-        raw_field_definitions = defaultdict(list)
-        for model_cls in models:
-            for name, field in model_cls.model_fields.items():
-                raw_field_definitions[name].append(
-                    (field.annotation, field.is_required())
-                )
-
-        field_definitions = {}
-        for name, definitions in raw_field_definitions.items():
-            types, requireds = zip(*definitions)
-
-            types = set(types)
-            if len(types) > 1:
-                raise RagnaException(f"Mismatching types for field {name}: {types}")
-            type_ = types.pop()
-
-            default = ... if any(requireds) else None
-
-            field_definitions[name] = (type_, default)
-
-        return cast(
-            Type[pydantic.BaseModel],
-            create_model(  # type: ignore[call-overload]
-                str(self.params["chat_id"]),
-                __config__=ConfigDict(extra="forbid"),
-                **field_definitions,
-            ),
-        )
 
     async def _enqueue(
         self, component: Type[Component], action: str, *args: Any

--- a/ragna/core/_utils.py
+++ b/ragna/core/_utils.py
@@ -9,9 +9,12 @@ import getpass
 import importlib
 import importlib.metadata
 import os
-from typing import Any, Collection, Union
+from collections import defaultdict
+
+from typing import Any, cast, Collection, Type, Union
 
 import packaging.requirements
+import pydantic
 
 from ragna._compat import importlib_metadata_package_distributions
 
@@ -116,3 +119,47 @@ def default_user() -> str:
     with contextlib.suppress(Exception):
         return os.getlogin()
     return "Ragna"
+
+
+def merge_models(
+    model_name: str, *models: Type[pydantic.BaseModel]
+) -> Type[pydantic.BaseModel]:
+    raw_field_definitions = defaultdict(list)
+    for model_cls in models:
+        for name, field in model_cls.model_fields.items():
+            raw_field_definitions[name].append(
+                (
+                    field.annotation,
+                    ...
+                    if field.is_required()
+                    else (
+                        field.default or field.default_factory()  # type: ignore[misc]
+                    ),
+                )
+            )
+
+    field_definitions = {}
+    for name, definitions in raw_field_definitions.items():
+        types, defaults = zip(*definitions)
+
+        types = set(types)
+        if len(types) > 1:
+            raise RagnaException(f"Mismatching types for field {name}: {types}")
+        type_ = types.pop()
+
+        defaults = set(defaults)
+        if len(defaults) == 1:
+            default = defaults.pop()
+        elif ... in defaults:
+            default = ...
+        else:
+            default = None
+
+        field_definitions[name] = (type_, default)
+
+    return cast(
+        Type[pydantic.BaseModel],
+        pydantic.create_model(  # type: ignore[call-overload]
+            model_name, **field_definitions
+        ),
+    )

--- a/scripts/add_chats.py
+++ b/scripts/add_chats.py
@@ -3,7 +3,7 @@ import json
 import os
 
 import httpx
-from ragna.core._rag import default_user
+from ragna.core._utils import default_user
 
 
 def main():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,6 @@
 import contextlib
 import functools
+import inspect
 import platform
 import shutil
 import socket
@@ -9,7 +10,6 @@ import threading
 import time
 
 import httpx
-
 import pytest
 import redis
 
@@ -37,6 +37,9 @@ def timeout_after(seconds=5, *, message=None):
     message = timeout if message is None else f"{timeout}: {message}"
 
     def decorator(fn):
+        if is_debugging():
+            return fn
+
         @functools.wraps(fn)
         def wrapper(*args, **kwargs):
             result = TimeoutError(message)
@@ -62,6 +65,23 @@ def timeout_after(seconds=5, *, message=None):
         return wrapper
 
     return decorator
+
+
+# Vendored from pytest-timeout
+# https://github.com/pytest-dev/pytest-timeout/blob/d91e6d8d69ad706e38a2c9de461a72c4d19777ff/pytest_timeout.py#L218-L247
+def is_debugging():
+    trace_func = sys.gettrace()
+    trace_module = None
+    if trace_func:
+        trace_module = inspect.getmodule(trace_func) or inspect.getmodule(
+            trace_func.__class__
+        )
+    if trace_module:
+        parts = trace_module.__name__.split(".")
+        for name in {"pydevd", "bdb", "pydevd_frame_evaluator"}:
+            if any(part.startswith(name) for part in parts):
+                return True
+    return False
 
 
 def get_available_port():


### PR DESCRIPTION
For the UI to know what parameters can be exposed to the user to tweak, we need to return this information from the API somehow. Fortunately, we are already using `pydantic` to validate the the `params` passed to each chat.

1. The `/components` endpoint now returns the JSON schema of each component. The name is behind the `"title"` key.
2. Following the same spirit, the `/components` endpoint now also returns a top level `"documents"` key that stores all supported suffixes.

Example:

```python
from pprint import pprint

import httpx

# assuming ragna api is started under this url
url = "http://127.0.0.1:31476"

token = (
    httpx.post(f"{url}/token", data={"username": "foo", "password": "foo"})
    .raise_for_status()
    .json()
)
pprint(
    httpx.get(f"{url}/components", headers={"Authorization": f"Bearer {token}"})
    .raise_for_status()
    .json(),
    sort_dicts=False,
)
```

before

```
{'source_storages': ['Chroma', 'Ragna/DemoSourceStorage', 'LanceDB'],
 'assistants': ['Ragna/DemoAssistant']}
```

after

```
{'documents': ['.pdf', '.txt'],
 'source_storages': [{'properties': {'chunk_size': {'default': 500,
                                                    'title': 'Chunk Size',
                                                    'type': 'integer'},
                                     'chunk_overlap': {'default': 250,
                                                       'title': 'Chunk Overlap',
                                                       'type': 'integer'},
                                     'num_tokens': {'default': 1024,
                                                    'title': 'Num Tokens',
                                                    'type': 'integer'}},
                      'required': [],
                      'title': 'Chroma',
                      'type': 'object'},
                     {'properties': {},
                      'required': [],
                      'title': 'Ragna/DemoSourceStorage',
                      'type': 'object'},
                     {'properties': {'chunk_size': {'default': 500,
                                                    'title': 'Chunk Size',
                                                    'type': 'integer'},
                                     'chunk_overlap': {'default': 250,
                                                       'title': 'Chunk Overlap',
                                                       'type': 'integer'},
                                     'num_tokens': {'default': 1024,
                                                    'title': 'Num Tokens',
                                                    'type': 'integer'}},
                      'required': [],
                      'title': 'LanceDB',
                      'type': 'object'}],
 'assistants': [{'properties': {},
                 'title': 'Ragna/DemoAssistant',
                 'type': 'object'}]}

```
