### PR TITLE
remove timezone offset from default timestamp of messages

### DIFF
--- a/ragna/_api/schemas.py
+++ b/ragna/_api/schemas.py
@@ -52,7 +52,7 @@ class Message(BaseModel):
     role: ragna.core.MessageRole
     sources: list[Source] = Field(default_factory=list)
     timestamp: datetime.datetime = Field(
-        default_factory=lambda: datetime.datetime.now(tz=datetime.timezone.utc)
+        default_factory=lambda: datetime.datetime.utcnow()
     )
 
     @classmethod


### PR DESCRIPTION


```python
from ragna.core import MessageRole
from ragna._api.schemas import Message

print(
    Message(content="", role=MessageRole.SYSTEM).model_dump(mode="json")["timestamp"],
)

```

before

```
2023-10-23T19:46:11.258707Z
```

after

```
2023-10-23T19:46:37.082318
```