### PR TITLE
increase test timeout

### DIFF
--- a/tests/api/test_e2e.py
+++ b/tests/api/test_e2e.py
@@ -46,7 +46,7 @@ def test_e2e(tmp_path, queue, database):
             check_api(config)
 
 
-@timeout_after(30)
+@timeout_after()
 def check_api(config):
     document_root = config.local_cache_root / "documents"
     document_root.mkdir()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -32,7 +32,7 @@ def background_subprocess(
             sys.stderr.flush()
 
 
-def timeout_after(seconds=5, *, message=None):
+def timeout_after(seconds=30, *, message=None):
     timeout = f"Timeout after {seconds:.1f} seconds"
     message = timeout if message is None else f"{timeout}: {message}"
 
@@ -159,7 +159,7 @@ def ragna_api(config, *, start_worker=None):
 
     with background_subprocess(cmd):
 
-        @timeout_after(20, message="Unable to start ragna api")
+        @timeout_after(message="Unable to start ragna api")
         def wait_for_ragna_api(poll=0.1):
             url = config.api.url
             while True:


### PR DESCRIPTION
I'm seeing quite a few timeouts in #61. Using a too short timeout is recipe for flaky CI. Let's up it a little and hope that this is the end of it.