### PR TITLE
quote the builtin install instructions

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -15,7 +15,7 @@ pip install ragna
 If you want to install all optional dependencies, append `[builtin]`:
 
 ```bash
-pip install ragna[builtin]
+pip install 'ragna[builtin]'
 ```
 
 And, upgrade to latest versions with:


### PR DESCRIPTION
@dharhas reported offline, that `pip install ragna[builtin]` doesn't work.

However, `pip install ragna[builtin]` works. In fact, this is what we use in CI to install our dependencies: https://github.com/Quansight/ragna/blob/a04efc2fbde3f44d541f6c49f84a92b4c91f2fc4/.github/actions/setup-env/action.yml#L61-L70

I don't have the actual error in front of me, but I'd wager a guess that something else than `bash` was used? 

In other shells, e.g. `zsh`, `[...]` has special meaning, There you would see
```
❯ pip install ragna[builtin]
zsh: no matches found: ragna[builtin]
```

Solution to this is simple: quote the offending part:
```
❯ pip install 'ragna[builtin]'
```

So this is a "user error". But I can see that this will be common enough. So let's just quote the installation instruction by default, as it has no negative effect other than "looking awkward".