### PR TITLE
refactor config wizard

### DIFF
--- a/ragna/_cli/config.py
+++ b/ragna/_cli/config.py
@@ -128,7 +128,7 @@ def _wizard_builtin() -> Config:
         Assistant,  # type: ignore[type-abstract]
     )
 
-    _handle_unment_requirements(
+    _handle_unmet_requirements(
         itertools.chain(config.core.source_storages, config.core.assistants)
     )
 
@@ -165,7 +165,7 @@ def _select_components(
     )
 
 
-def _handle_unment_requirements(components: Iterable[Type[Component]]) -> None:
+def _handle_unmet_requirements(components: Iterable[Type[Component]]) -> None:
     unmet_requirements = set(
         itertools.chain.from_iterable(
             component.requirements() for component in components

--- a/ragna/_cli/config.py
+++ b/ragna/_cli/config.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from pathlib import Path
 from types import ModuleType
-from typing import TYPE_CHECKING, Annotated, Type, TypeVar, cast
+from typing import TYPE_CHECKING, Annotated, Iterable, Type, TypeVar, cast
 
 import questionary
 import rich
@@ -21,39 +21,31 @@ from ragna.core._components import Component
 
 
 def parse_config(value: str) -> Config:
-    if value == "demo":
-        config = Config.demo()
-    elif value == "builtin":
-        config = Config.builtin()
-    else:
-        config = Config.from_file(value)
-    config.__ragna_cli_value__ = value
+    config = Config.from_file(value)
+    # This stores the original value so we can pass it on to subprocesses that we might
+    # start.
+    config.__ragna_cli_config_path__ = value
     return config
 
 
-COMMON_CONFIG_OPTION_ARGS = ("-c", "--config")
-COMMON_CONFIG_OPTION_KWARGS = dict(
-    metavar="CONFIG",
-    envvar="RAGNA_CONFIG",
-    parser=parse_config,
-    help=(
-        "Configuration to use. "
-        "Can be path to a Ragna configuration file, 'demo', or 'builtin'.\n\n"
-        "If 'demo', loads a minimal configuration without persistent state.\n\n"
-        "If 'builtin', loads a configuration with all available builtin components, "
-        "but without extra infrastructure requirements."
-    ),
-)
 ConfigOption = Annotated[
     ragna.Config,
-    typer.Option(*COMMON_CONFIG_OPTION_ARGS, **COMMON_CONFIG_OPTION_KWARGS),
+    typer.Option(
+        "-c",
+        "--config",
+        metavar="CONFIG",
+        envvar="RAGNA_CONFIG",
+        parser=parse_config,
+        show_default=False,
+        help="Path to a Ragna configuration file.",
+    ),
 ]
 
 # This adds a newline before every question to unclutter the output
 QMARK = "\n?"
 
 
-def config_wizard(*, output_path: Path, force: bool) -> tuple[Config, Path, bool]:
+def init_config(*, output_path: Path, force: bool) -> tuple[Config, Path, bool]:
     # FIXME: add link to the config documentation when it is available
     rich.print(
         "\n\t[bold]Welcome to the Ragna config creation wizard![/bold]\n\n"
@@ -61,34 +53,44 @@ def config_wizard(*, output_path: Path, force: bool) -> tuple[Config, Path, bool
         "Due to the large amount of parameters, "
         "I unfortunately can't cover everything. "
         "If you want to customize everything, "
-        "you can have a look at the documentation instead."
+        "please have a look at the documentation instead."
     )
 
     intent = questionary.select(
         "Which of the following statements describes best what you want to do?",
         choices=[
             questionary.Choice(
-                "I want to try Ragna "
-                "without worrying about any additional dependencies or setup.",
+                (
+                    "I want to try Ragna without worrying about any additional "
+                    "dependencies or setup."
+                ),
                 value="demo",
             ),
             questionary.Choice(
-                "I want to try Ragna and its builtin components.",
+                (
+                    "I want to try Ragna and its builtin source storages and "
+                    "assistants, which potentially require additional dependencies "
+                    "or setup."
+                ),
                 value="builtin",
             ),
             questionary.Choice(
-                "I want to customize the most common parameters.",
+                (
+                    "I have used Ragna before and want to customize the most common "
+                    "parameters."
+                ),
                 value="common",
             ),
         ],
         qmark=QMARK,
     ).unsafe_ask()
 
-    config = {
+    wizard = {
         "demo": _wizard_demo,
         "builtin": _wizard_builtin,
         "common": _wizard_common,
-    }[intent]()  # type: ignore[operator]
+    }[intent]
+    config = wizard()
 
     if output_path.exists() and not force:
         output_path, force = _handle_output_path(output_path=output_path, force=force)
@@ -101,56 +103,72 @@ def config_wizard(*, output_path: Path, force: bool) -> tuple[Config, Path, bool
     return config, output_path, force
 
 
-def _print_special_config(name: str) -> None:
-    rich.print(
-        f"For this use case the {name} configuration is the perfect fit!\n"
-        f"Hint for the future: the demo configuration can also be accessed by passing "
-        f"--config {name} to ragna commands without the need for an actual "
-        f"configuration file."
-    )
-
-
 def _wizard_demo() -> Config:
-    _print_special_config("demo")
-    return Config.demo()
+    return Config()
 
 
-def _wizard_builtin(*, hint_builtin: bool = True) -> Config:
-    config = Config.builtin()
+def _wizard_builtin() -> Config:
+    config = _wizard_demo()
 
-    intent = questionary.select(
-        "How do you want to select the components?",
-        choices=[
-            questionary.Choice(
-                (
-                    "I want to use all builtin components "
-                    "for which the requirements are met."
-                ),
-                value="builtin",
-            ),
-            questionary.Choice(
-                "I want to manually select the builtin components I want to use.",
-                value="custom",
-            ),
-        ],
-        qmark=QMARK,
-    ).unsafe_ask()
+    unmet_requirements: set[Requirement] = set()
 
-    if intent == "builtin":
-        if hint_builtin:
-            _print_special_config("builtin")
-        return config
-
-    config.core.source_storages = _select_components(
+    config.core.source_storages, partial_unmet_requirements = _select_components(
         "source storages",
         ragna.source_storages,
         SourceStorage,  # type: ignore[type-abstract]
     )
-    config.core.assistants = _select_components(
+    unmet_requirements.update(partial_unmet_requirements)
+
+    config.core.assistants, partial_unmet_requirements = _select_components(
         "assistants",
         ragna.assistants,
         Assistant,  # type: ignore[type-abstract]
     )
+    unmet_requirements.update(partial_unmet_requirements)
+
+    if unmet_requirements:
+        rich.print(
+            "You have selected components, which have additional requirements that are"
+            "currently not met."
+        )
+        unmet_requirements_by_type = _split_requirements(unmet_requirements)
+
+        unmet_package_requirements = sorted(
+            str(requirement)
+            for requirement in unmet_requirements_by_type[PackageRequirement]
+        )
+        if unmet_package_requirements:
+            rich.print(
+                "\nTo use the selected components, "
+                "you need to install the following packages: \n"
+            )
+            for requirement in unmet_package_requirements:
+                rich.print(f"- {requirement}")
+
+            rich.print(
+                f"\nTo do this, you can run\n\n"
+                f"$ pip install {' '.join(unmet_package_requirements)}\n\n"
+                f"Optionally, you can also install Ragna with all optional dependencies"
+                f"for the builtin components\n\n"
+                f"$ pip install 'ragna\[builtin]'"
+            )
+
+        unmet_env_var_requirements = sorted(
+            str(requirement)
+            for requirement in unmet_requirements_by_type[EnvVarRequirement]
+        )
+        if unmet_env_var_requirements:
+            rich.print(
+                "\nTo use the selected components, "
+                "you need to set the following environment variables: \n"
+            )
+            for requirement in unmet_env_var_requirements:
+                rich.print(f"- {requirement}")
+
+        rich.print(
+            "\nTip: You can check the availability of the requirements with "
+            "[bold]ragna check[/bold]."
+        )
 
     return config
 
@@ -160,11 +178,11 @@ T = TypeVar("T", bound=Component)
 
 def _select_components(
     title: str, module: ModuleType, base_cls: Type[T]
-) -> list[Type[T]]:
+) -> tuple[list[Type[T]], set[Requirement]]:
     selected_components: list[Type[T]] = questionary.checkbox(
         (
             f"ragna has the following {title} builtin. "
-            f"Choose the he ones you want to use. "
+            f"Choose the ones you want to use. "
             f"If the requirements of a selected component are not met, "
             f"I'll ask for confirmation later."
         ),
@@ -185,15 +203,17 @@ def _select_components(
         qmark=QMARK,
     ).unsafe_ask()
 
+    unmet_requirements: set[Requirement] = set()
     for component in [
         component for component in selected_components if not component.is_available()
     ]:
         rich.print(
-            f"The component {component.display_name()} "
+            f"The component [bold]{component.display_name()}[/bold] "
             f"has the following requirements that are currently not fully met:\n"
         )
 
-        requirements = _split_requirements(component.requirements())
+        requirements = component.requirements()
+        requirements_by_type = _split_requirements(requirements)
         for title, requirement_type in [
             ("Installed packages:", PackageRequirement),
             ("Environment variables:", EnvVarRequirement),
@@ -201,24 +221,32 @@ def _select_components(
             if TYPE_CHECKING:
                 requirement_type = cast(Type[Requirement], requirement_type)
 
-            if requirement_type in requirements:
+            if requirement_type in requirements_by_type:
                 rich.print(f"{title}\n")
-                rich.print(f"{_format_requirements(requirements[requirement_type])}\n")
+                rich.print(
+                    f"{_format_requirements(requirements_by_type[requirement_type])}\n"
+                )
 
-        if not questionary.confirm(
+        if questionary.confirm(
             (
                 f"Are you able to meet these requirements in the future and "
                 f"thus want to include {component.display_name()} in the configuration?"
             ),
             qmark=QMARK,
         ).unsafe_ask():
+            unmet_requirements.update(
+                requirement
+                for requirement in requirements
+                if not requirement.is_available()
+            )
+        else:
             selected_components.remove(component)
 
-    return selected_components
+    return selected_components, unmet_requirements
 
 
 def _wizard_common() -> Config:
-    config = _wizard_builtin(hint_builtin=False)
+    config = _wizard_builtin()
 
     config.local_cache_root = Path(
         questionary.path(
@@ -319,7 +347,7 @@ def _select_queue_url(config: Config) -> str:
 
 def _handle_output_path(*, output_path: Path, force: bool) -> tuple[Path, bool]:
     rich.print(
-        f"The output path {output_path} already exists "
+        f"\nThe output path {output_path} already exists "
         f"and you didn't pass the --force flag to overwrite it. "
     )
     action = questionary.select(
@@ -395,7 +423,7 @@ def check_config(config: Config) -> bool:
 
 
 def _split_requirements(
-    requirements: list[Requirement],
+    requirements: Iterable[Requirement],
 ) -> dict[Type[Requirement], list[Requirement]]:
     split_reqs = defaultdict(list)
     for req in requirements:

--- a/ragna/_cli/core.py
+++ b/ragna/_cli/core.py
@@ -72,7 +72,7 @@ def init(
 
 
 @app.command(help="Check the availability of components.")
-def check(config: ConfigOption) -> None:
+def check(config: ConfigOption = "./ragna.toml") -> None:
     is_available = check_config(config)
     raise typer.Exit(int(not is_available))
 
@@ -80,7 +80,7 @@ def check(config: ConfigOption) -> None:
 @app.command(help="Start workers.")
 def worker(
     *,
-    config: ConfigOption,
+    config: ConfigOption = "./ragna.toml",
     num_threads: Annotated[
         int,
         typer.Option("--num-threads", "-n", help="Number of worker threads to start."),
@@ -101,7 +101,7 @@ def worker(
 @app.command(help="Start the REST API.")
 def api(
     *,
-    config: ConfigOption,
+    config: ConfigOption = "./ragna.toml",
     start_worker: Annotated[
         Optional[bool],
         typer.Option(
@@ -148,7 +148,7 @@ def api(
 @app.command(help="Start the UI.")
 def ui(
     *,
-    config: ConfigOption,
+    config: ConfigOption = "./ragna.toml",
     start_api: Annotated[
         Optional[bool],
         typer.Option(

--- a/ragna/_cli/core.py
+++ b/ragna/_cli/core.py
@@ -72,7 +72,7 @@ def init(
 
 
 @app.command(help="Check the availability of components.")
-def check(config: ConfigOption = "./ragna.toml") -> None:
+def check(config: ConfigOption = "./ragna.toml") -> None:  # type: ignore[assignment]
     is_available = check_config(config)
     raise typer.Exit(int(not is_available))
 
@@ -80,7 +80,7 @@ def check(config: ConfigOption = "./ragna.toml") -> None:
 @app.command(help="Start workers.")
 def worker(
     *,
-    config: ConfigOption = "./ragna.toml",
+    config: ConfigOption = "./ragna.toml",  # type: ignore[assignment]
     num_threads: Annotated[
         int,
         typer.Option("--num-threads", "-n", help="Number of worker threads to start."),
@@ -101,7 +101,7 @@ def worker(
 @app.command(help="Start the REST API.")
 def api(
     *,
-    config: ConfigOption = "./ragna.toml",
+    config: ConfigOption = "./ragna.toml",  # type: ignore[assignment]
     start_worker: Annotated[
         Optional[bool],
         typer.Option(
@@ -148,7 +148,7 @@ def api(
 @app.command(help="Start the UI.")
 def ui(
     *,
-    config: ConfigOption = "./ragna.toml",
+    config: ConfigOption = "./ragna.toml",  # type: ignore[assignment]
     start_api: Annotated[
         Optional[bool],
         typer.Option(

--- a/ragna/_cli/core.py
+++ b/ragna/_cli/core.py
@@ -68,6 +68,7 @@ def init(
     ] = False,
 ) -> None:
     config, output_path, force = init_config(output_path=output_path, force=force)
+    config.to_file(output_path, force=force)
 
 
 @app.command(help="Check the availability of components.")

--- a/ragna/_cli/core.py
+++ b/ragna/_cli/core.py
@@ -17,13 +17,7 @@ from ragna._ui import app as ui_app
 from ragna._utils import timeout_after
 from ragna.core._queue import Queue
 
-from .config import (
-    COMMON_CONFIG_OPTION_ARGS,
-    COMMON_CONFIG_OPTION_KWARGS,
-    ConfigOption,
-    check_config,
-    config_wizard,
-)
+from .config import ConfigOption, check_config, init_config
 
 app = typer.Typer(
     name="ragna",
@@ -52,8 +46,8 @@ def _main(
     pass
 
 
-@app.command(help="Create or check configurations.")
-def config(
+@app.command(help="Start a wizard to build a Ragna configuration interactively.")
+def init(
     *,
     output_path: Annotated[
         Path,
@@ -66,24 +60,6 @@ def config(
             help="Write configuration to <OUTPUT_PATH>.",
         ),
     ],
-    config: Annotated[
-        Optional[ragna.Config],
-        typer.Option(
-            *COMMON_CONFIG_OPTION_ARGS,
-            **COMMON_CONFIG_OPTION_KWARGS,
-            show_default="Start a wizard to build the configuration interactively.",
-        ),
-    ] = None,
-    check: Annotated[
-        bool,
-        typer.Option(
-            "--check",
-            help=(
-                "Display the availability for all selected components in <CONFIG>. "
-                "If given, no file is generated at <OUTPUT_PATH>."
-            ),
-        ),
-    ] = False,
     force: Annotated[
         bool,
         typer.Option(
@@ -91,25 +67,19 @@ def config(
         ),
     ] = False,
 ) -> None:
-    if config is None:
-        if check:
-            rich.print(
-                "--check makes no sense without passing a config with -c / --config"
-            )
-            raise typer.Exit(1)
-        config, output_path, force = config_wizard(output_path=output_path, force=force)
+    config, output_path, force = init_config(output_path=output_path, force=force)
 
-    if check:
-        is_available = check_config(config)
-        raise typer.Exit(int(not is_available))
 
-    config.to_file(output_path, force=force)
+@app.command(help="Check the availability of components.")
+def check(config: ConfigOption) -> None:
+    is_available = check_config(config)
+    raise typer.Exit(int(not is_available))
 
 
 @app.command(help="Start workers.")
 def worker(
     *,
-    config: ConfigOption = "builtin",  # type: ignore[assignment]
+    config: ConfigOption,
     num_threads: Annotated[
         int,
         typer.Option("--num-threads", "-n", help="Number of worker threads to start."),
@@ -130,7 +100,7 @@ def worker(
 @app.command(help="Start the REST API.")
 def api(
     *,
-    config: ConfigOption = "builtin",  # type: ignore[assignment]
+    config: ConfigOption,
     start_worker: Annotated[
         Optional[bool],
         typer.Option(
@@ -150,7 +120,7 @@ def api(
                 "ragna",
                 "worker",
                 "--config",
-                config.__ragna_cli_value__,  # type: ignore[attr-defined]
+                config.__ragna_cli_config_path__,  # type: ignore[attr-defined]
             ],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -177,7 +147,7 @@ def api(
 @app.command(help="Start the UI.")
 def ui(
     *,
-    config: ConfigOption = "builtin",  # type: ignore[assignment]
+    config: ConfigOption,
     start_api: Annotated[
         Optional[bool],
         typer.Option(
@@ -204,7 +174,7 @@ def ui(
                 "ragna",
                 "api",
                 "--config",
-                config.__ragna_cli_value__,  # type: ignore[attr-defined]
+                config.__ragna_cli_config_path__,  # type: ignore[attr-defined]
             ],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/ragna/core/_config.py
+++ b/ragna/core/_config.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import secrets
 from pathlib import Path
-from types import ModuleType
-from typing import Type, Union
+from typing import Union
 
 import tomlkit
 from pydantic import Field, ImportString, field_validator
@@ -119,34 +118,3 @@ class Config(BaseSettings):
 
         with open(path, "w") as file:
             tomlkit.dump(self.model_dump(mode="json"), file)
-
-    @classmethod
-    def demo(cls) -> ragna.Config:
-        return cls()
-
-    @classmethod
-    def builtin(cls) -> ragna.Config:
-        from ragna import assistants, source_storages
-        from ragna.core import Assistant, SourceStorage
-        from ragna.core._components import Component
-
-        def get_available_components(
-            module: ModuleType, cls: Type[Component]
-        ) -> list[Type]:
-            return [
-                obj
-                for obj in module.__dict__.values()
-                if isinstance(obj, type) and issubclass(obj, cls) and obj.is_available()
-            ]
-
-        config = cls()
-
-        config.core.queue_url = str(config.local_cache_root / "queue")
-        config.core.source_storages = get_available_components(
-            source_storages, SourceStorage
-        )
-        config.core.assistants = get_available_components(assistants, Assistant)
-
-        config.api.database_url = f"sqlite:///{config.local_cache_root}/ragna.db"
-
-        return config

--- a/ragna/core/_utils.py
+++ b/ragna/core/_utils.py
@@ -56,6 +56,15 @@ class Requirement(abc.ABC):
     def __repr__(self) -> str:
         ...
 
+    def __hash__(self) -> int:
+        return hash(repr(self))
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, Requirement):
+            return NotImplemented
+
+        return repr(self) == repr(other)
+
 
 class RequirementsMixin:
     @classmethod


### PR DESCRIPTION
This is my proposed solution for #124. It implements the following changes:

- Remove the `demo` and `builtin` special configuration options. Note that the previous `Config.demo()` is still available, since that just created a `Config()` with default values anyway:
  https://github.com/Quansight/ragna/blob/a04efc2fbde3f44d541f6c49f84a92b4c91f2fc4/ragna/core/_config.py#L123-L125
- Remove the default value for `-c` / `--config`. `ragna worker`, `ragna api`, and `ragna ui` now require passing a configuration.
- Split `ragna config` and `ragna config --check` into `ragna init` and `ragna check`. `ragna init` is the configuration wizard and `ragna check` can be with configuration files to check availability of the requirements.
- Improve the wizard by printing a summary of the unmet requirements as well as instructions on how to meet them.
- A few phrasing improvements in the wizard.