### PR TITLE
allow API token secret to be set through env var

### DIFF
--- a/ragna/_api/core.py
+++ b/ragna/_api/core.py
@@ -121,9 +121,7 @@ def app(config: Config) -> FastAPI:
                 detail="Ragna configuration does not support local upload",
             )
         with get_session() as session:
-            user, id = ragna.core.LocalDocument.decode_upload_token(
-                token, secret=rag.config.api.upload_token_secret
-            )
+            user, id = ragna.core.LocalDocument.decode_upload_token(token)
             document, metadata = database.get_document(session, user=user, id=id)
 
             core_document = ragna.core.LocalDocument(

--- a/ragna/core/_config.py
+++ b/ragna/core/_config.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import secrets
 from pathlib import Path
 from typing import Union
 
@@ -64,11 +63,6 @@ class ApiConfig(BaseSettings):
     authentication: ImportString[
         type[Authentication]
     ] = "ragna.core.RagnaDemoAuthentication"  # type: ignore[assignment]
-
-    upload_token_secret: str = Field(
-        default_factory=lambda: secrets.token_urlsafe(32)[:32]
-    )
-    upload_token_ttl: int = 5 * 60
 
 
 class UiConfig(BaseSettings):


### PR DESCRIPTION
Without this, restarting the API will invalidate all active tokens up to this point, since they API has a new secret to verify them. The old default behavior is preserved. Meaning, if you don't set the `RAGNA_DEMO_AUTHENTICATION_SECRET` env var, we'll use a random on that changes with every start of the API.

This also removes the option to set the document upload secret for local documents through the configuration file. We shouldn't have done that in the first place. It can still be set through the same env var `RAGNA_API_DOCUMENT_UPLOAD_SECRET` as before.