### PR TITLE
config quick fix : disable sliders if "Ragna/Demo"

### DIFF
--- a/ragna/_ui/styles.py
+++ b/ragna/_ui/styles.py
@@ -139,6 +139,22 @@ label, .bk-slider-title {
 .noUi-handle, .noUi-connects {
     background-color: var(--clear-button-active);
 }
+
+.noUi-target[disabled='true'] {
+    border-color: darkgray;
+}
+
+
+.noUi-target[disabled='true'] .noUi-connect {
+    background-color: darkgray !important;
+}
+
+
+:host(.disabled) div.bk-slider-title {
+    color: darkgray !important;
+}
+
+
 """
 
 


### PR DESCRIPTION
This PR is a quick fix to disable sliders in advanced config when the assistant or the source storage has "Ragna/Demo" in it.

Later we'll generate the advanced config dynamically based on the API result for the "components" endpoint (I actually have quite advanced work on that but I have a bug in Panel that prevents me from delivering a proper PR)