### PR TITLE
pin pymupdf to latest release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ all = [
     "chromadb>=0.4.13",
     "lancedb>=0.2",
     "pyarrow",
-    "pymupdf",
+    "pymupdf>=1.23.6",
     "tiktoken",
 ]
 

--- a/ragna/core/_document.py
+++ b/ragna/core/_document.py
@@ -247,13 +247,7 @@ class PdfDocumentHandler(DocumentHandler):
 
     @classmethod
     def requirements(cls) -> list[Requirement]:
-        return [
-            PackageRequirement(
-                "pymupdf",
-                # See https://github.com/Quansight/ragna/issues/75
-                exclude_modules=["fitz_new"],
-            )
-        ]
+        return [PackageRequirement("pymupdf>=1.23.6")]
 
     @classmethod
     def supported_suffixes(cls) -> list[str]:

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -4,8 +4,6 @@ fixed upstream. If you see a test failing here, i.e. an unexpected success, feel
 remove the offending test after you have cleaned up our code.
 """
 
-import subprocess
-import sys
 
 import pytest
 
@@ -20,13 +18,3 @@ def test_pyarrow_dummy_module():
         if "pyarrow" in distribution_names
     }
     assert "__dummy__" not in module_names
-
-
-@pytest.mark.xfail
-def test_pymupdf_import_warning():
-    # See https://github.com/Quansight/ragna/issues/75
-    result = subprocess.run(
-        [sys.executable, "-c", "import fitz_new"], capture_output=True
-    )
-    assert not result.stdout
-    assert not result.stderr


### PR DESCRIPTION
The latest release removes the warning on import that we saw in #75.