### PR TITLE
Update assistant timeout to accomodate longer response time.

### DIFF
--- a/ragna/assistants/_api.py
+++ b/ragna/assistants/_api.py
@@ -26,7 +26,7 @@ class ApiAssistant(Assistant):
 
         self._client = httpx.Client(
             headers={"User-Agent": f"{ragna.__version__}/{self}"},
-            timeout=30,
+            timeout=60,
         )
         self._api_key = os.environ[self._API_KEY_ENV_VAR]
 


### PR DESCRIPTION
Relating to:
https://github.com/Quansight/ragna/issues/174

An improvement idea is that we can have streaming input check for those api that support this (e.g GPT). This way we know that it's still generating output rather than a network problem.