### PR TITLE
cache importlib_metadata_package_distributions

### DIFF
--- a/ragna/core/_utils.py
+++ b/ragna/core/_utils.py
@@ -17,6 +17,10 @@ import pydantic_core
 
 from ragna._compat import importlib_metadata_package_distributions
 
+importlib_metadata_package_distributions = functools.cache(
+    importlib_metadata_package_distributions
+)
+
 
 class RagnaExceptionHttpDetail(enum.Enum):
     EVENT = enum.auto()


### PR DESCRIPTION
Closes #181. `package_distributions` seems to involve heavy path operations that we only need to perform once. On my system, this nets us a 4x decrease in function calls and 2.5 seconds faster import. On slower file systems the latter number is probably even more pronounced. Benchmark in https://github.com/Quansight/ragna/issues/181#issuecomment-1802868433. 

Thanks @nenb for pointing this out!