### PR TITLE
make config optional when creating a component

### DIFF
--- a/ragna/assistants/_api.py
+++ b/ragna/assistants/_api.py
@@ -1,5 +1,6 @@
 import abc
 import os
+from typing import Optional
 
 import ragna
 from ragna.core import (
@@ -19,7 +20,7 @@ class ApiAssistant(Assistant):
     def requirements(cls) -> list[Requirement]:
         return [EnvVarRequirement(cls._API_KEY_ENV_VAR)]
 
-    def __init__(self, config: Config) -> None:
+    def __init__(self, config: Optional[Config] = None) -> None:
         super().__init__(config)
 
         import httpx

--- a/ragna/core/_components.py
+++ b/ragna/core/_components.py
@@ -34,6 +34,8 @@ class Component(RequirementsMixin):
         return cls.__name__
 
     def __init__(self, config: Optional[Config] = None) -> None:
+        from ._config import Config
+
         self.config = config or Config()
 
     def __repr__(self) -> str:

--- a/ragna/core/_components.py
+++ b/ragna/core/_components.py
@@ -4,7 +4,7 @@ import abc
 import enum
 import functools
 import inspect
-from typing import TYPE_CHECKING, Type
+from typing import TYPE_CHECKING, Optional, Type
 
 import pydantic
 import pydantic.utils
@@ -33,8 +33,8 @@ class Component(RequirementsMixin):
         """
         return cls.__name__
 
-    def __init__(self, config: Config) -> None:
-        self.config = config
+    def __init__(self, config: Optional[Config] = None) -> None:
+        self.config = config or Config()
 
     def __repr__(self) -> str:
         return self.display_name()

--- a/ragna/source_storages/_chroma.py
+++ b/ragna/source_storages/_chroma.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import Optional
 
 from ragna.core import (
     Config,
@@ -20,7 +21,7 @@ class Chroma(VectorDatabaseSourceStorage):
     # Note that this class has no extra requirements, since the chromadb package is
     # already required for the base class.
 
-    def __init__(self, config: Config) -> None:
+    def __init__(self, config: Optional[Config] = None) -> None:
         super().__init__(config)
 
         import chromadb

--- a/ragna/source_storages/_demo.py
+++ b/ragna/source_storages/_demo.py
@@ -1,5 +1,6 @@
 import textwrap
 import uuid
+from typing import Optional
 
 from ragna.core import Config, Document, Source, SourceStorage
 
@@ -19,7 +20,7 @@ class RagnaDemoSourceStorage(SourceStorage):
     def display_name(cls) -> str:
         return "Ragna/DemoSourceStorage"
 
-    def __init__(self, config: Config) -> None:
+    def __init__(self, config: Optional[Config] = None) -> None:
         super().__init__(config)
         self._storage: dict[uuid.UUID, list[Source]] = {}
 

--- a/ragna/source_storages/_lancedb.py
+++ b/ragna/source_storages/_lancedb.py
@@ -34,7 +34,7 @@ class LanceDB(VectorDatabaseSourceStorage):
         import lancedb
         import pyarrow as pa
 
-        self._db = lancedb.connect(config.local_cache_root / "lancedb")
+        self._db = lancedb.connect(self.config.local_cache_root / "lancedb")
         self._schema = pa.schema(
             [
                 pa.field("id", pa.string()),

--- a/ragna/source_storages/_lancedb.py
+++ b/ragna/source_storages/_lancedb.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import Optional
 
 from ragna.core import Config, Document, PackageRequirement, Requirement, Source
 
@@ -27,7 +28,7 @@ class LanceDB(VectorDatabaseSourceStorage):
             ),
         ]
 
-    def __init__(self, config: Config) -> None:
+    def __init__(self, config: Optional[Config] = None) -> None:
         super().__init__(config)
 
         import lancedb

--- a/ragna/source_storages/_vector_database.py
+++ b/ragna/source_storages/_vector_database.py
@@ -64,7 +64,7 @@ class VectorDatabaseSourceStorage(SourceStorage):
             PackageRequirement("tiktoken"),
         ]
 
-    def __init__(self, config: Config):
+    def __init__(self, config: Optional[Config] = None):
         super().__init__(config)
 
         import chromadb.api


### PR DESCRIPTION
I feel it is kinda annoying to always pass a config when trying to instantiate a component, e.g. https://github.com/Quansight/ragna/issues/189#issuecomment-1804771900. There should be no harm to provide a default. When the components are instantiated for the queue we always pass a config

https://github.com/Quansight/ragna/blob/dc497ef4768b8f8bd4d5c3736eb1d67b27050387/ragna/core/_queue.py#L126-L130

Meaning, we can be sure that all components that are used "in process" receive the right config.