### PR TITLE
fix LanceDB retrieval

### DIFF
--- a/ragna/source_storages/_lancedb.py
+++ b/ragna/source_storages/_lancedb.py
@@ -99,7 +99,10 @@ class LanceDB(VectorDatabaseSourceStorage):
         # retrieving to few sources and needed to query again.
         limit = int(num_tokens * 2 / chunk_size)
         results = (
-            table.search(vector_column_name=self._VECTOR_COLUMN_NAME)
+            table.search(
+                self._embedding_function([prompt])[0],
+                vector_column_name=self._VECTOR_COLUMN_NAME,
+            )
             .limit(limit)
             .to_arrow()
         )


### PR DESCRIPTION
Fixes #193. 

`<rant>`
What a horrible UX that just let's the user pass nothing for the query in a vector search. I mean, what is the vector search supposed to do if it has nothing to compare against. :rage:
`</rant>`