### PR TITLE
docs: small improvements to "Set Configuration" how-to

### DIFF
--- a/docs/how-tos/set-configuration.md
+++ b/docs/how-tos/set-configuration.md
@@ -58,4 +58,5 @@ config = Config.from_file(config_path)
 ```
 
 !!! note
+
     In the Python API, the [`Rag.chat()` function](../references/python-api.md#ragna.core.Chat) also allows you to set certain RAG-specific configurations like `document` and `assistants`.

--- a/docs/how-tos/set-configuration.md
+++ b/docs/how-tos/set-configuration.md
@@ -46,8 +46,8 @@ url = "http://127.0.0.1:31477"
 You can use `ragna.toml` for setting configurations in your applications:
 
 <!--
-Using `py``` instesd of `python`` allows for syntax highlighting without doctesting.
-This is a work around until https://github.com/koaning/mktestdocs/issues/7 is implemented.
+Using `py``` instead of `python`` allows for syntax highlighting without doctesting.
+This is a workaround until https://github.com/koaning/mktestdocs/issues/7 is implemented.
 -->
 
 ```py
@@ -58,5 +58,4 @@ config = Config.from_file(config_path)
 ```
 
 !!! note
-
-    In the Python API, the `Rag.chat()` function also allows you to set certain RAG-specific configurations like `document` and `assistants`.
+    In the Python API, the [`Rag.chat()` function](../references/python-api.md#ragna.core.Chat) also allows you to set certain RAG-specific configurations like `document` and `assistants`.

--- a/docs/how-tos/set-configuration.md
+++ b/docs/how-tos/set-configuration.md
@@ -59,4 +59,4 @@ config = Config.from_file(config_path)
 
 !!! note
 
-    In the Python API, the [`Rag.chat()` function](../references/python-api.md#ragna.core.Chat) also allows you to set certain RAG-specific configurations like `document` and `assistants`.
+    In the Python API, the [ragna.Rag.chat][] function also allows you to set certain RAG-specific configurations like `document` and `assistants`.


### PR DESCRIPTION
## Summary

Small docs improvements to "Set Configuration" page

## Details

- add link to the referenced `Rag.chat()` function

- ~remove new line after `!!! note`~
  - ~otherwise most markdown editors will recognize the block as a code block due to the 4 space indentation (same as #196)~
  - **EDIT**: reverted due to `prettier` per review comments, c.f. https://github.com/Quansight/ragna/pull/197#pullrequestreview-1726123408

- fix typo: "instesd" -> "instead"