### PR TITLE
add comparison workflow example

### DIFF
--- a/comparison.py
+++ b/comparison.py
@@ -1,0 +1,68 @@
+import asyncio
+import itertools
+from pprint import pprint
+
+from tqdm import tqdm
+from tqdm.asyncio import tqdm_asyncio
+
+from ragna import Rag, assistants, source_storages
+
+SOURCE_STORAGES = [
+    source_storages.Chroma,
+    source_storages.LanceDB,
+]
+ASSISTANTS = [
+    assistants.Gpt35Turbo16k,
+    assistants.Gpt4,
+]
+
+
+async def main():
+    rag = Rag()
+
+    # Pre-load all components to enable a fair comparison
+    for component in itertools.chain(SOURCE_STORAGES, ASSISTANTS):
+        rag._load_component(component)
+
+    document = "ragna.txt"
+    with open(document, "w") as file:
+        file.write("Ragna is an open source RAG orchestration framework\n")
+
+    prompt = "What is Ragna?"
+
+    experiments = make_experiments(rag=rag, prompt=prompt, document=document)
+    pprint(
+        {name: await experiment for name, experiment in tqdm(experiments.items())},
+        sort_dicts=False,
+    )
+
+    experiments = make_experiments(rag=rag, prompt=prompt, document=document)
+    pprint(
+        dict(zip(experiments.keys(), await tqdm_asyncio.gather(*experiments.values()))),
+        sort_dicts=False,
+    )
+
+
+def make_experiments(*, rag, document, prompt):
+    return {
+        f"{source_storage.display_name()} / {assistant.display_name()}": answer(
+            rag=rag,
+            documents=[document],
+            source_storage=source_storage,
+            assistant=assistant,
+            prompt=prompt,
+        )
+        for source_storage, assistant in itertools.product(SOURCE_STORAGES, ASSISTANTS)
+    }
+
+
+async def answer(*, rag, documents, source_storage, assistant, prompt):
+    chat = rag.chat(
+        documents=documents, source_storage=source_storage, assistant=assistant
+    )
+    await chat.prepare()
+    return (await chat.answer(prompt)).content
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/ragna/core/_rag.py
+++ b/ragna/core/_rag.py
@@ -45,7 +45,7 @@ class Rag(Generic[C]):
             cls = component
             instance = None
         else:
-            raise RagnaException
+            raise RagnaException("Unknown component", component=component)
 
         if cls not in self._components:
             if instance is None:


### PR DESCRIPTION
Addresses #18. This shows two things:

1. How to compare multiple components with each other.
2. How to effectively use async programming to speed this up.

I don't intend to merge this PR as we need to have something like that as part of our documentation. But it can serve as base for future work.

@nenb You might also be able to use this for the comparisons you wanted to do in https://github.com/Quansight/ragna/pull/205#issuecomment-1817982107.

Here is the progress bar output on my machine:

```
100%|█████████████████████████████████████████████████████████████████████████| 4/4 [00:38<00:00,  9.61s/it]
100%|█████████████████████████████████████████████████████████████████████████| 4/4 [00:17<00:00,  4.31s/it]
```

So we are roughly twice as fast with utilizing async. This of course will vary a lot for different source storages / assistants / documents / prompts. So we cannot ever report a number here unless we create a fixed test scenario first.