### PR TITLE
fix chat info

### DIFF
--- a/ragna/deploy/_ui/central_view.py
+++ b/ragna/deploy/_ui/central_view.py
@@ -255,21 +255,9 @@ class CentralView(pn.viewable.Viewer):
 
             grid_height = len(self.current_chat["metadata"]["documents"]) // 3
 
-            advanced_config_data = {
-                "Chunk size": self.current_chat["metadata"]["params"]["chunk_size"],
-                "Chunk overlap": self.current_chat["metadata"]["params"][
-                    "chunk_overlap"
-                ],
-                "Max context tokens": self.current_chat["metadata"]["params"][
-                    "num_tokens"
-                ],
-                "Max new tokens": self.current_chat["metadata"]["params"][
-                    "max_new_tokens"
-                ],
-            }
-
             advanced_config_md = "\n".join(
-                [f"""- **{k}**: {v}""" for k, v in advanced_config_data.items()]
+                f"- **{key.replace('_', ' ').title()}**: {value}"
+                for key, value in self.current_chat["metadata"]["params"].items()
             )
 
             markdown = [


### PR DESCRIPTION
Fixes #219. The issue here is that we are hardcoding some chat params, but we cannot guarantee that they are present. This should have been done together with #155.

In general, we don't want to hardcode anything in the UI in the near future, so this is a first step towards 3. of #217. The solution is not perfect as we are basically just displaying the name of the parameter variables rather than an adjusted human readable version, but it is good enough for now.