### PR TITLE
remove [BUG] and [ENH] classifier from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,7 +1,6 @@
 name: "Bug report 🐛"
 description: "Create a report to help us fix something that is currently broken."
-title: "<title>"
-labels: ["type: bug"]
+labels: ["type: bug 🐛"]
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,7 +1,7 @@
 name: "Bug report 🐛"
 description: "Create a report to help us fix something that is currently broken."
-title: "[BUG] - <title>"
-labels: ["type: bug 🐛"]
+title: "<title>"
+labels: ["type: bug"]
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,7 +1,7 @@
 name: "Feature request ✨"
 description: "Create a feature request to help Ragna improve"
-title: "[ENH] - <title>"
-labels: ["type: enhancement 💅"]
+title: "<title>"
+labels: ["type: enhancement"]
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,7 +1,6 @@
 name: "Feature request ✨"
 description: "Create a feature request to help Ragna improve"
-title: "<title>"
-labels: ["type: enhancement"]
+labels: ["type: enhancement 💅"]
 
 body:
   - type: markdown


### PR DESCRIPTION
Having these prefixes is redundant with our labels. We shouldn't have both.