### PR TITLE
set hard limit of visible document pills

### DIFF
--- a/ragna/deploy/_ui/central_view.py
+++ b/ragna/deploy/_ui/central_view.py
@@ -588,7 +588,10 @@ class CentralView(pn.viewable.Viewer):
         ):
             doc_names = [d["name"] for d in self.current_chat["metadata"]["documents"]]
 
-            for doc_name in doc_names:
+            # FIXME: Instead of setting a hard limit of 20 documents here, this should
+            #  scale automatically with the width of page
+            #  See https://github.com/Quansight/ragna/issues/224
+            for doc_name in doc_names[:20]:
                 pill = pn.pane.HTML(
                     f"""<div class="chat_document_pill">{doc_name}</div>""",
                     stylesheets=[


### PR DESCRIPTION
Addressed #224. 20 visible documents is probably too high in most if not all cases, but at least it prevents the UI from becoming sluggish if one has 2k+ documents. Meaning, this does not prevent the "overflow" in most cases, but prevents a performance hit in the more extreme cases.