### PR TITLE
Make document upload method flexible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ testpaths = [
     "tests",
 ]
 filterwarnings = [
-    "error",
+#    "error",
     # This is coming from the nested dependency
     # chromadb -> opentelemetry-exporter-otlp-proto-grpc -> googleapis-common-protos
     # This will be resolved by https://github.com/googleapis/python-api-common-protos/pull/187

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ testpaths = [
     "tests",
 ]
 filterwarnings = [
-#    "error",
+    "error",
     # This is coming from the nested dependency
     # chromadb -> opentelemetry-exporter-otlp-proto-grpc -> googleapis-common-protos
     # This will be resolved by https://github.com/googleapis/python-api-common-protos/pull/187

--- a/ragna/core/__init__.py
+++ b/ragna/core/__init__.py
@@ -4,6 +4,7 @@ __all__ = [
     "Component",
     "Document",
     "DocumentHandler",
+    "DocumentUploadParameters",
     "EnvVarRequirement",
     "LocalDocument",
     "Message",
@@ -31,6 +32,7 @@ from ._utils import (
 from ._document import (
     Document,
     DocumentHandler,
+    DocumentUploadParameters,
     LocalDocument,
     Page,
     PdfDocumentHandler,

--- a/ragna/core/_document.py
+++ b/ragna/core/_document.py
@@ -17,6 +17,12 @@ if TYPE_CHECKING:
     from ragna.deploy import Config
 
 
+class DocumentUploadParameters(BaseModel):
+    method: str
+    url: str
+    data: dict
+
+
 class Document(RequirementsMixin, abc.ABC):
     """Abstract base class for all documents."""
 
@@ -59,7 +65,7 @@ class Document(RequirementsMixin, abc.ABC):
     @abc.abstractmethod
     async def get_upload_info(
         cls, *, config: Config, user: str, id: uuid.UUID, name: str
-    ) -> tuple[str, dict[str, Any], dict[str, Any]]:
+    ) -> tuple[dict[str, Any], DocumentUploadParameters]:
         pass
 
     @abc.abstractmethod
@@ -136,7 +142,7 @@ class LocalDocument(Document):
     @classmethod
     async def get_upload_info(
         cls, *, config: Config, user: str, id: uuid.UUID, name: str
-    ) -> tuple[str, dict[str, Any], dict[str, Any]]:
+    ) -> tuple[dict[str, Any], DocumentUploadParameters]:
         url = f"{config.api.url}/document"
         data = {
             "token": jwt.encode(
@@ -150,7 +156,7 @@ class LocalDocument(Document):
             )
         }
         metadata = {"path": str(config.local_cache_root / "documents" / str(id))}
-        return url, data, metadata
+        return metadata, DocumentUploadParameters(method="PUT", url=url, data=data)
 
     @classmethod
     def decode_upload_token(cls, token: str) -> tuple[str, uuid.UUID]:

--- a/ragna/deploy/_api/core.py
+++ b/ragna/deploy/_api/core.py
@@ -119,14 +119,11 @@ def app(config: Config) -> FastAPI:
     ) -> schemas.DocumentUpload:
         with get_session() as session:
             document = schemas.Document(name=name)
-            (
-                document_metadata,
-                parameters,
-            ) = await config.document.get_upload_info(
+            metadata, parameters = await config.document.get_upload_info(
                 config=config, user=user, id=document.id, name=document.name
             )
             database.add_document(
-                session, user=user, document=document, metadata=document_metadata
+                session, user=user, document=document, metadata=metadata
             )
             return schemas.DocumentUpload(parameters=parameters, document=document)
 

--- a/ragna/deploy/_api/core.py
+++ b/ragna/deploy/_api/core.py
@@ -127,7 +127,7 @@ def app(config: Config) -> FastAPI:
             )
             return schemas.DocumentUploadInfo(url=url, data=data, document=document)
 
-    @app.put("/document")
+    @app.post("/document")
     async def upload_document(
         token: Annotated[str, Form()], file: UploadFile
     ) -> schemas.Document:

--- a/ragna/deploy/_api/core.py
+++ b/ragna/deploy/_api/core.py
@@ -116,18 +116,21 @@ def app(config: Config) -> FastAPI:
     async def create_document_upload_info(
         user: UserDependency,
         name: Annotated[str, Body(..., embed=True)],
-    ) -> schemas.DocumentUploadInfo:
+    ) -> schemas.DocumentUpload:
         with get_session() as session:
             document = schemas.Document(name=name)
-            url, data, metadata = await config.document.get_upload_info(
+            (
+                document_metadata,
+                parameters,
+            ) = await config.document.get_upload_info(
                 config=config, user=user, id=document.id, name=document.name
             )
             database.add_document(
-                session, user=user, document=document, metadata=metadata
+                session, user=user, document=document, metadata=document_metadata
             )
-            return schemas.DocumentUploadInfo(url=url, data=data, document=document)
+            return schemas.DocumentUpload(parameters=parameters, document=document)
 
-    @app.post("/document")
+    @app.put("/document")
     async def upload_document(
         token: Annotated[str, Form()], file: UploadFile
     ) -> schemas.Document:

--- a/ragna/deploy/_api/schemas.py
+++ b/ragna/deploy/_api/schemas.py
@@ -27,9 +27,8 @@ class Document(BaseModel):
         )
 
 
-class DocumentUploadInfo(BaseModel):
-    url: str
-    data: dict
+class DocumentUpload(BaseModel):
+    parameters: ragna.core.DocumentUploadParameters
     document: Document
 
 

--- a/ragna/deploy/_ui/resources/upload.js
+++ b/ragna/deploy/_ui/resources/upload.js
@@ -21,7 +21,7 @@ async function uploadFile(file, token, informationEndpoint) {
   body.append("file", file);
 
   await fetch(documentInfo.url, {
-    method: "PUT",
+    method: "POST",
     body: body,
   });
 

--- a/ragna/deploy/_ui/resources/upload.js
+++ b/ragna/deploy/_ui/resources/upload.js
@@ -12,18 +12,19 @@ async function uploadFile(file, token, informationEndpoint) {
     headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
     body: JSON.stringify({ name: file.name }),
   });
-  const documentInfo = await response.json();
+  const documentUpload = await response.json();
 
+  const parameters = documentUpload.parameters;
   var body = new FormData();
-  for (const [key, value] of Object.entries(documentInfo.data)) {
+  for (const [key, value] of Object.entries(parameters.data)) {
     body.append(key, value);
   }
   body.append("file", file);
 
-  await fetch(documentInfo.url, {
-    method: "POST",
+  await fetch(parameters.url, {
+    method: parameters.method,
     body: body,
   });
 
-  return documentInfo.document;
+  return documentUpload.document;
 }

--- a/scripts/add_chats.py
+++ b/scripts/add_chats.py
@@ -34,15 +34,17 @@ def main():
     documents = []
     for i in range(5):
         name = f"document{i}.txt"
-        document_info = (
+        document_upload = (
             client.post("/document", json={"name": name}).raise_for_status().json()
         )
-        client.post(
-            document_info["url"],
-            data=document_info["data"],
+        parameters = document_upload["parameters"]
+        client.request(
+            parameters["method"],
+            parameters["url"],
+            data=parameters["data"],
             files={"file": f"Content of {name}".encode()},
         ).raise_for_status()
-        documents.append(document_info["document"])
+        documents.append(document_upload["document"])
 
     ## chat 1
 

--- a/scripts/add_chats.py
+++ b/scripts/add_chats.py
@@ -37,7 +37,7 @@ def main():
         document_info = (
             client.post("/document", json={"name": name}).raise_for_status().json()
         )
-        client.put(
+        client.post(
             document_info["url"],
             data=document_info["data"],
             files={"file": f"Content of {name}".encode()},

--- a/tests/deploy/api/test_e2e.py
+++ b/tests/deploy/api/test_e2e.py
@@ -57,12 +57,12 @@ def check_api(config):
         document = document_upload["document"]
         assert document["name"] == document_path.name
 
-        request_parameters = document_upload["request_parameters"]
+        parameters = document_upload["parameters"]
         with open(document_path, "rb") as file:
             client.request(
-                request_parameters["method"],
-                request_parameters["url"],
-                data=request_parameters["data"],
+                parameters["method"],
+                parameters["url"],
+                data=parameters["data"],
                 files={"file": file},
             )
 

--- a/tests/deploy/api/test_e2e.py
+++ b/tests/deploy/api/test_e2e.py
@@ -49,20 +49,22 @@ def check_api(config):
 
         assert client.get("/chats").raise_for_status().json() == []
 
-        document_info = (
+        document_upload = (
             client.post("/document", json={"name": document_path.name})
             .raise_for_status()
             .json()
         )
-        document = document_info["document"]
+        document = document_upload["document"]
         assert document["name"] == document_path.name
 
+        request_parameters = document_upload["request_parameters"]
         with open(document_path, "rb") as file:
-            client.put(
-                document_info["url"],
-                data=document_info["data"],
+            client.request(
+                request_parameters["method"],
+                request_parameters["url"],
+                data=request_parameters["data"],
                 files={"file": file},
-            ).raise_for_status()
+            )
 
         components = client.get("/components").raise_for_status().json()
         documents = components["documents"]


### PR DESCRIPTION
Unfortunately, #186 was not enough. While we can use PUT to actually upload the document, other backends, e.g. AWS S3, need to use POST. To support both use cases, we extend the functionality of the document upload info to also return the method the end user needs to use. Basically, we are providing the full request parameters.