### PR TITLE
fix large upload #176

### DIFF
--- a/ragna/deploy/_ui/resources/upload.js
+++ b/ragna/deploy/_ui/resources/upload.js
@@ -1,26 +1,23 @@
 function upload(files, token, informationEndpoint, final_callback) {
+  uploadBatches(files, token, informationEndpoint).then(final_callback);
+}
 
-  async function uploadBatches() {
+async function uploadBatches(files, token, informationEndpoint) {
+  const batchSize = 500;
+  const queue = Array.from(files);
 
-    let index = 0;
-    let uploaded = [];
+  let uploaded = [];
 
-    const batchSize = 500;
-    const queue = Array.from(files);
-
-    while(index < files.length) {
-      const batch = queue.splice(0, batchSize);
-      await Promise.all(
-        batch.map(file => uploadFile(file, token, informationEndpoint))
-      ).then(results => {
-        uploaded.push(...results);
-      });
-      index += batch.length;
-    }
-    return(uploaded);
+  while (queue.length) {
+    const batch = queue.splice(0, batchSize);
+    await Promise.all(
+      batch.map((file) => uploadFile(file, token, informationEndpoint)),
+    ).then((results) => {
+      uploaded.push(...results);
+    });
   }
 
-  uploadBatches().then(final_callback);
+  return uploaded;
 }
 
 async function uploadFile(file, token, informationEndpoint) {

--- a/ragna/deploy/_ui/resources/upload.js
+++ b/ragna/deploy/_ui/resources/upload.js
@@ -1,35 +1,25 @@
-function upload(files, token, informationsEndpoint, final_callback) {
-  const batchSize = 500; // Maximum number of concurrent uploads
-  let currentIndex = 0; // Tracks the index of the current file to be uploaded
-  let successfullyUploaded = []; // Array to hold the results
+function upload(files, token, informationEndpoint, final_callback) {
 
-  // Function to upload a single batch of files
-  function uploadBatch() {
-    // Get the next batch of files based on the current index and batch size
-    const batch = Array.from(files).slice(currentIndex, currentIndex + batchSize);
-    currentIndex += batchSize;
-    // Map over the batch to create an array of upload promises
-    return Promise.all(
-      batch.map(file => uploadFile(file, token, informationsEndpoint))
-    ).then(results => {
-      // Concatenate the results of the current batch to the main array
-      successfullyUploaded = successfullyUploaded.concat(results);
-      // If there are more files to upload, recursively call uploadBatch again
-      if (currentIndex < files.length) {
-        return uploadBatch();
-      } else {
-        // If all files are uploaded, invoke the final callback with the results
-        final_callback(successfullyUploaded);
-      }
-    });
+  async function uploadBatches() {
+    const queue = Array.from(files)
+
+    const batchSize = 500;
+    let index = 0;
+    let uploaded = [];
+
+    while(index < files.length) {
+      const batch = queue.splice(0, batchSize);
+      await Promise.all(
+        batch.map(file => uploadFile(file, token, informationEndpoint))
+      ).then(results => {
+        uploaded.push(...results);
+      });
+      index += batch.length;
+    }
+    return(uploaded);
   }
 
-  // Start uploading the first batch
-  uploadBatch().catch(error => {
-    console.error("An error occurred during the upload process", error);
-    // You might want to call your final callback with an error or partial results
-    final_callback(successfullyUploaded);
-  });
+  uploadBatches().then(final_callback);
 }
 
 async function uploadFile(file, token, informationEndpoint) {

--- a/ragna/deploy/_ui/resources/upload.js
+++ b/ragna/deploy/_ui/resources/upload.js
@@ -1,11 +1,12 @@
 function upload(files, token, informationEndpoint, final_callback) {
 
   async function uploadBatches() {
-    const queue = Array.from(files)
 
-    const batchSize = 500;
     let index = 0;
     let uploaded = [];
+
+    const batchSize = 500;
+    const queue = Array.from(files);
 
     while(index < files.length) {
       const batch = queue.splice(0, batchSize);

--- a/ragna/deploy/_ui/resources/upload.js
+++ b/ragna/deploy/_ui/resources/upload.js
@@ -1,9 +1,35 @@
 function upload(files, token, informationsEndpoint, final_callback) {
-  Promise.all(
-    Array.from(files).map((file) => {
-      return uploadFile(file, token, informationsEndpoint);
-    }),
-  ).then(final_callback);
+  const batchSize = 500; // Maximum number of concurrent uploads
+  let currentIndex = 0; // Tracks the index of the current file to be uploaded
+  let successfullyUploaded = []; // Array to hold the results
+
+  // Function to upload a single batch of files
+  function uploadBatch() {
+    // Get the next batch of files based on the current index and batch size
+    const batch = Array.from(files).slice(currentIndex, currentIndex + batchSize);
+    currentIndex += batchSize;
+    // Map over the batch to create an array of upload promises
+    return Promise.all(
+      batch.map(file => uploadFile(file, token, informationsEndpoint))
+    ).then(results => {
+      // Concatenate the results of the current batch to the main array
+      successfullyUploaded = successfullyUploaded.concat(results);
+      // If there are more files to upload, recursively call uploadBatch again
+      if (currentIndex < files.length) {
+        return uploadBatch();
+      } else {
+        // If all files are uploaded, invoke the final callback with the results
+        final_callback(successfullyUploaded);
+      }
+    });
+  }
+
+  // Start uploading the first batch
+  uploadBatch().catch(error => {
+    console.error("An error occurred during the upload process", error);
+    // You might want to call your final callback with an error or partial results
+    final_callback(successfullyUploaded);
+  });
 }
 
 async function uploadFile(file, token, informationEndpoint) {


### PR DESCRIPTION
Fixes #176.

Batch concurrent file uploads from upload dialog to handle thousands of documents without browser lock ups.