### PR TITLE
Fix rendering of chat info button

### DIFF
--- a/ragna/deploy/_ui/central_view.py
+++ b/ragna/deploy/_ui/central_view.py
@@ -243,17 +243,14 @@ class CentralView(pn.viewable.Viewer):
 
         self.api_wrapper = api_wrapper
         self.chat_info_button = pn.widgets.Button(
-            name="", button_style="outline", icon="info-circle"
+            # The name will be filled at runtime in self.header
+            name="",
+            on_click=self.on_click_chat_info_wrapper,
+            button_style="outline",
+            icon="info-circle",
+            stylesheets=[":host { margin-top:10px; }"],
         )
         self.on_click_chat_info = None
-        self.chat_info_button.stylesheets.append(
-            """ 
-            :host {  
-                margin-top:10px;
-                }                    
-            """
-        )
-        self.chat_info_button.on_click(self.on_click_chat_info_wrapper)
 
     def on_click_chat_info_wrapper(self, event):
         if self.on_click_chat_info is not None:

--- a/ragna/deploy/_ui/central_view.py
+++ b/ragna/deploy/_ui/central_view.py
@@ -242,7 +242,18 @@ class CentralView(pn.viewable.Viewer):
         super().__init__(**params)
 
         self.api_wrapper = api_wrapper
+        self.chat_info_button = pn.widgets.Button(
+            name="", button_style="outline", icon="info-circle"
+        )
         self.on_click_chat_info = None
+        self.chat_info_button.stylesheets.append(
+            """ 
+            :host {  
+                margin-top:10px;
+                }                    
+            """
+        )
+        self.chat_info_button.on_click(self.on_click_chat_info_wrapper)
 
     def on_click_chat_info_wrapper(self, event):
         if self.on_click_chat_info is not None:
@@ -613,26 +624,12 @@ class CentralView(pn.viewable.Viewer):
 
                 chat_documents_pills.append(pill)
 
-        chat_info_button = None
-        if self.current_chat is not None:
-            button_name = f"{self.current_chat['metadata']['assistant']} | {self.current_chat['metadata']['source_storage']}"
-            chat_info_button = pn.widgets.Button(
-                name=button_name, button_style="outline", icon="info-circle"
-            )
-            chat_info_button.stylesheets.append(
-                """
-                                        :host {  
-                                                    margin-top:10px;
-                                        }
-                                        
-                                    """
-            )
-            chat_info_button.on_click(self.on_click_chat_info_wrapper)
+        self.chat_info_button.name = f"{self.current_chat['metadata']['assistant']} | {self.current_chat['metadata']['source_storage']}"
 
         return pn.Row(
             chat_name_header,
             *chat_documents_pills,
-            chat_info_button,
+            self.chat_info_button,
             stylesheets=[
                 """:host {  
                                     background-color: #F9F9F9;


### PR DESCRIPTION
Addresses #229. 

Currently a new chat info button is created whenever the UI is updated. This creates a problem as when the UI is re-rendered it is still referencing the original button (which has not actually been updated). To fix this issue a button should only be created once and then updated in place prior to each re-render.