### PR TITLE
add functionality to format CSS stylesheets

### DIFF
--- a/ragna/deploy/_ui/central_view.py
+++ b/ragna/deploy/_ui/central_view.py
@@ -293,39 +293,35 @@ class CentralView(pn.viewable.Viewer):
                         dedent=True,
                         # debug
                         # pn.pane.Markdown(f"Chat ID: {self.current_chat['id']}"),
-                        stylesheets=[
-                            """ :host {  width: 100%; } 
-                                                 
-                                                .pills_list {
-                                                    /*background-color:gold;*/
-                                                    display: grid;
-                                                    grid-auto-flow: row;
-                                                    row-gap: 10px;
-                                                    grid-template: repeat({{GRID_HEIGHT}}, 1fr) / repeat(3, 1fr);
-                                                    max-height: 200px;
-                                                    overflow: scroll;
-                                                }
-                                                 
-                                                .chat_document_pill {
-                                                                    background-color: rgb(241,241,241);
-                                                                    
-                                                                    margin-left: 5px;   
-                                                                    margin-right: 5px;
-                                                                    padding: 5px 15px;
-                                                                    border-radius: 10px;
-                                                                    color:var(--accent-color);
-                                                                    width:fit-content;
-                                                                    grid-column: span 1;
-                                                                    
-                                                                }   
-                                                ul {
-                                                    list-style-type: none
-                                                }                                                 
-
-                                                """.replace(
-                                "{{GRID_HEIGHT}}", str(grid_height)
-                            )
-                        ],
+                        stylesheets=ui.stylesheets(
+                            (":host", {"width": "100%"}),
+                            (
+                                ".pills_list",
+                                {
+                                    # "background-color": "gold",
+                                    "display": "grid",
+                                    "grid-auto-flow": "row",
+                                    "row-gap": "10px",
+                                    "grid-template": f"repeat({grid_height}, 1fr) / repeat(3, 1fr)",
+                                    "max-height": "200px",
+                                    "overflow": "scroll",
+                                },
+                            ),
+                            (
+                                ".chat_document_pill",
+                                {
+                                    "background-color": "rgb(241,241,241)",
+                                    "margin-left": "5px",
+                                    "margin-right": "5px",
+                                    "padding": "5px 15px",
+                                    "border-radius": "10px",
+                                    "color": "var(--accent-color)",
+                                    "width": "fit-content",
+                                    "grid-column": "span 1",
+                                },
+                            ),
+                            ("ul", {"list-style-type": "none"}),
+                        ),
                     ),
                 ],
             )

--- a/ragna/deploy/_ui/styles.py
+++ b/ragna/deploy/_ui/styles.py
@@ -1,6 +1,8 @@
 """
 UI Helpers
 """
+from typing import Optional
+
 import panel as pn
 
 
@@ -11,6 +13,26 @@ def divider():
 """
 CSS constants
 """
+
+
+def stylesheets(*class_selectors: tuple[str, dict[str, str]]) -> Optional[list[str]]:
+    if not class_selectors:
+        return None
+
+    return [
+        "\n".join(
+            [
+                f"{selector} {{",
+                *[
+                    f"    {property}: {value};"
+                    for property, value in declarations.items()
+                ],
+                "}",
+            ]
+        )
+        for selector, declarations in class_selectors
+    ]
+
 
 MAIN_COLOR = "#DF5538"  # "rgba(223, 85, 56, 1)"
 


### PR DESCRIPTION
The more I look at our UI code, the more frustrated I grow about the way we define the `stylesheets` for the various panel components. Putting everything into one massive multiline string works, but has two downsides:

1. The formatting is all over the place, since the auto-formatters won't format it at all.
2. Inserting values is not easy, since in CSS braces, i.e. `{}`, are regular characters. Meaning, if we used f-strings, we would need to encode them all the time. We currently use `.format()` for this.

This PR adds a `stylesheets` function that takes two-tuples of CSS selectors and declarations. That way we can use regular Python syntax to define everything and fixing both issues above.

I've applied this to one instance of our code in this PR. If we move forward with this, I'll open an issue and asking for help of the community to fix the rest of the code.