### PR TITLE
fix source view on messages that were generated in a previous session

### DIFF
--- a/ragna/deploy/_ui/central_view.py
+++ b/ragna/deploy/_ui/central_view.py
@@ -402,6 +402,7 @@ class CentralView(pn.viewable.Viewer):
                     user=self.get_user_from_role(message["role"]),
                     sources=message["sources"],
                     timestamp=message["timestamp"],
+                    on_click_source_info_callback=self.on_click_source_info_wrapper,
                 )
                 for message in self.current_chat["messages"]
             ],


### PR DESCRIPTION
I forgot to construct the initial messages, i.e. the ones we get back from the DB when starting the UI, with the source view callback in #261. When clicking the button on such a message we would get an error in the browser console as well as in the console and in the UI nothing would happen.