### PR TITLE
Fix environment-dev.yml

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -5,7 +5,6 @@ dependencies:
   - python =3.9
   - pip
   - pip:
-      - jupyter
       - python-dotenv
       - boto3
       - pytest >=6


### PR DESCRIPTION
When I create the `mamba` environment via `mamba env create --file environment-dev.yml` and then install the project dependencies via `pyproject.toml`, `ipython` is broken for me.

Traceback:
```
Traceback (most recent call last):
  File "/Users/nenb/miniforge3/envs/ragna-dev/bin/ipython", line 8, in <module>
    sys.exit(start_ipython())
  File "/Users/nenb/miniforge3/envs/ragna-dev/lib/python3.9/site-packages/IPython/__init__.py", line 129, in start_ipython
    return launch_new_instance(argv=argv, **kwargs)
  File "/Users/nenb/miniforge3/envs/ragna-dev/lib/python3.9/site-packages/traitlets/config/application.py", line 1075, in launch_instance
    app.start()
  File "/Users/nenb/miniforge3/envs/ragna-dev/lib/python3.9/site-packages/IPython/terminal/ipapp.py", line 317, in start
    self.shell.mainloop()
  File "/Users/nenb/miniforge3/envs/ragna-dev/lib/python3.9/site-packages/IPython/terminal/interactiveshell.py", line 887, in mainloop
    self.interact()
  File "/Users/nenb/miniforge3/envs/ragna-dev/lib/python3.9/site-packages/IPython/terminal/interactiveshell.py", line 872, in interact
    code = self.prompt_for_code()
  File "/Users/nenb/miniforge3/envs/ragna-dev/lib/python3.9/site-packages/IPython/terminal/interactiveshell.py", line 813, in prompt_for_code
    text = self.pt_app.prompt(
TypeError: prompt() got an unexpected keyword argument 'inputhook'

If you suspect this is an IPython 8.18.0 bug, please report it at:
    https://github.com/ipython/ipython/issues
or send an email to the mailing list at ipython-dev@python.org

You can print a more detailed traceback right now with "%tb", or use "%debug"
to interactively debug it.
```

My understanding is this error is related to the fact that `ipython` (installed via `jupyter` by `mamba`) has a lower pin on `prompt-toolkit` of [3.0.41](https://github.com/ipython/ipython/blob/b14df3808a86bb1c9565816d15be4a52bc694c2a/setup.cfg#L38), whereas `questionary` (installed by `pip`) has an upper pin of [3.0.36](https://github.com/tmbo/questionary/blob/c894eeffbeb2f1448a108163998ba95b72a8e32a/pyproject.toml#L36C42-L36C42). A conflict arises because `pip` is not fully aware of what `mamba` has installed, and so `ipython` is broken for me in the current environment.

The quickest solution that I can think of is to remove `jupyter` (and hence `ipython`) from the `mamba` environment, and instead install manually with `pip` at the very end of the process eg `python -m pip install 'prompt_toolkit>=2.0,<=3.0.36' 'ipython<=8.16'`.

Perhaps there is a cleaner solution in which case I will close this PR. If not, I would like to consider merging it, as `ipython` is a useful tool when prototyping in the terminal.