### PR TITLE
Increase API timeout and add custom message

### DIFF
--- a/ragna/_utils.py
+++ b/ragna/_utils.py
@@ -74,9 +74,9 @@ def handle_localhost_origins(origins: list[str]) -> list[str]:
 
 
 def timeout_after(
-    seconds: float = 60, *, message: str = ""
+    seconds: float = 30, *, message: str = ""
 ) -> Callable[[Callable], Callable]:
-    timeout = f"Timeout after {seconds:.1f} seconds. This is likely due to a failure to start the API."
+    timeout = f"Timeout after {seconds:.1f} seconds"
     message = timeout if message else f"{timeout}: {message}"
 
     def decorator(fn: Callable) -> Callable:

--- a/ragna/_utils.py
+++ b/ragna/_utils.py
@@ -76,7 +76,7 @@ def handle_localhost_origins(origins: list[str]) -> list[str]:
 def timeout_after(
     seconds: float = 60, *, message: str = ""
 ) -> Callable[[Callable], Callable]:
-    timeout = f"Timeout after {seconds:.1f} seconds"
+    timeout = f"Timeout after {seconds:.1f} seconds. This is likely due to a failure to start the API."
     message = timeout if message else f"{timeout}: {message}"
 
     def decorator(fn: Callable) -> Callable:

--- a/ragna/_utils.py
+++ b/ragna/_utils.py
@@ -74,7 +74,7 @@ def handle_localhost_origins(origins: list[str]) -> list[str]:
 
 
 def timeout_after(
-    seconds: float = 30, *, message: str = ""
+    seconds: float = 60, *, message: str = ""
 ) -> Callable[[Callable], Callable]:
     timeout = f"Timeout after {seconds:.1f} seconds"
     message = timeout if message else f"{timeout}: {message}"

--- a/ragna/deploy/_cli/core.py
+++ b/ragna/deploy/_cli/core.py
@@ -131,15 +131,19 @@ def ui(
     try:
         if process is not None:
 
-            @timeout_after(
-                60,
-                'Failed to start the API in 60 seconds. Please start it manually with the command "ragna api".',
-            )
+            @timeout_after(60)
             def wait_for_api() -> None:
                 while not check_api_available():
                     time.sleep(0.5)
 
-            wait_for_api()
+            try:
+                wait_for_api()
+            except TimeoutError:
+                rich.print(
+                    "Failed to start the API in 60 seconds. "
+                    "Please start it manually with [bold]ragna api[/bold]."
+                )
+                raise typer.Exit(1)
 
         ui_app(config).serve()  # type: ignore[no-untyped-call]
     finally:

--- a/ragna/deploy/_cli/core.py
+++ b/ragna/deploy/_cli/core.py
@@ -133,7 +133,7 @@ def ui(
 
             @timeout_after(
                 60,
-                "Failed to start the API in 60 seconds. Please start it manually with ragna API.",
+                'Failed to start the API in 60 seconds. Please start it manually with the command "ragna api".',
             )
             def wait_for_api() -> None:
                 while not check_api_available():

--- a/ragna/deploy/_cli/core.py
+++ b/ragna/deploy/_cli/core.py
@@ -136,7 +136,10 @@ def ui(
                 while not check_api_available():
                     time.sleep(0.5)
 
-            wait_for_api()
+            wait_for_api(
+                60,
+                "Could not launch the UI. This is likely due to a failure to start the API.",
+            )
 
         ui_app(config).serve()  # type: ignore[no-untyped-call]
     finally:

--- a/ragna/deploy/_cli/core.py
+++ b/ragna/deploy/_cli/core.py
@@ -131,15 +131,15 @@ def ui(
     try:
         if process is not None:
 
-            @timeout_after()
+            @timeout_after(
+                60,
+                "Could not launch the UI. This is likely due to a failure to start the API.",
+            )
             def wait_for_api() -> None:
                 while not check_api_available():
                     time.sleep(0.5)
 
-            wait_for_api(
-                60,
-                "Could not launch the UI. This is likely due to a failure to start the API.",
-            )
+            wait_for_api()
 
         ui_app(config).serve()  # type: ignore[no-untyped-call]
     finally:

--- a/ragna/deploy/_cli/core.py
+++ b/ragna/deploy/_cli/core.py
@@ -133,7 +133,7 @@ def ui(
 
             @timeout_after(
                 60,
-                "Could not launch the UI. This is likely due to a failure to start the API.",
+                "Failed to start the API in 60 seconds. Please start it manually with ragna API.",
             )
             def wait_for_api() -> None:
                 while not check_api_available():


### PR DESCRIPTION
Issue #277 asked for two small things:

1. Increase time to timeout from 30 seconds to 60 seconds
2. Add clarification to error message when timeout happens

This small pull request does those two things. 

Please let me know if I should add/change anything. All constructive feedback is welcome.