### PR TITLE
fix invalid escape warning when building docs

### DIFF
--- a/ragna/deploy/_cli/config.py
+++ b/ragna/deploy/_cli/config.py
@@ -8,6 +8,7 @@ import pydantic
 import questionary
 import rich
 import typer
+from rich.markup import escape
 from rich.table import Table
 
 import ragna
@@ -213,7 +214,7 @@ def _handle_unmet_requirements(components: Iterable[Type[Component]]) -> None:
             f"$ pip install {' '.join(unmet_package_requirements)}\n\n"
             f"Optionally, you can also install Ragna with all optional dependencies"
             f"for the builtin components\n\n"
-            f"$ pip install 'ragna\[all]'"
+            f"$ pip install '{escape('ragna[all]')}"
         )
 
     unmet_env_var_requirements = sorted(


### PR DESCRIPTION
When building the docs, we can see the following warning

```
INFO    -  DeprecationWarning: invalid escape sequence \[
             File "/home/philip/git/ora/ragna/deploy/_cli/core.py", line 18, in <module>
               from .config import ConfigOption, check_config, init_config
             File "/home/philip/git/ora/ragna/deploy/_cli/config.py", line 216, in
               f"$ pip install 'ragna\[all]'"
```

This comes from

https://github.com/Quansight/ragna/blob/8aa6bd09740be0bed6391fab00323caf4889f369/ragna/deploy/_cli/config.py#L211-L217

We need to escape the backslash there, since `rich` would otherwise interpret the `[all]` as [markup](https://rich.readthedocs.io/en/stable/markup.html#console-markup).

This PR uses the `rich` functionality to escape instead. This gives the same result for `rich`, but also resolves the warning.