### PR TITLE
update outdated actions

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -14,7 +14,7 @@ runs:
 
   steps:
     - name: Setup mambaforge and development environment
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         miniforge-variant: Mambaforge
         miniforge-version: latest

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -34,7 +34,7 @@ runs:
 
     - name: Restore conda environment
       id: cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ env.CONDA }}/envs
         key:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,7 +55,7 @@ jobs:
           echo "cache-dir=${CACHE_DIR}" | tee --append $GITHUB_OUTPUT
 
       - name: Restore docker cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.cache.outputs.cache-dir }}
           key: docker-${{ hashFiles('Dockerfile','requirements-docker.lock') }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           optional-dependencies: "false"
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ hashFiles('.pre-commit-config.yaml') }}


### PR DESCRIPTION
Just caught this warning in CI: https://github.com/Quansight/ragna/actions/runs/7903868013?pr=320

![image](https://github.com/Quansight/ragna/assets/6849766/f63ad03f-94a2-4f32-9dd8-0bfa3be8c694)

This PR updates the outdated actions that we are using.