### PR TITLE
Remove duplicate call to answer method when not streaming

### DIFF
--- a/ragna/deploy/_api/core.py
+++ b/ragna/deploy/_api/core.py
@@ -241,9 +241,8 @@ def app(config: Config) -> FastAPI:
             )
             core_chat = schema_to_core_chat(session, user=user, chat=chat)
 
-        core_answer = await core_chat.answer(prompt, stream=True)
-
         if stream:
+            core_answer = await core_chat.answer(prompt, stream=True)
             message_chunk = schemas.Message(
                 content="",
                 role=core_answer.role,

--- a/ragna/deploy/_api/core.py
+++ b/ragna/deploy/_api/core.py
@@ -241,8 +241,9 @@ def app(config: Config) -> FastAPI:
             )
             core_chat = schema_to_core_chat(session, user=user, chat=chat)
 
+        core_answer = await core_chat.answer(prompt, stream=stream)
+
         if stream:
-            core_answer = await core_chat.answer(prompt, stream=True)
             message_chunk = schemas.Message(
                 content="",
                 role=core_answer.role,
@@ -268,7 +269,7 @@ def app(config: Config) -> FastAPI:
                 message_chunks()
             )
         else:
-            answer = schemas.Message.from_core(await core_chat.answer(prompt))
+            answer = schemas.Message.from_core(core_answer)
 
             with get_session() as session:
                 chat.messages.append(answer)


### PR DESCRIPTION
`await core_chat.answer(...)` is also called again inside the non-streaming block of code.