### PR TITLE
Add chat-identifiers endpoint

### DIFF
--- a/ragna/deploy/_api/core.py
+++ b/ragna/deploy/_api/core.py
@@ -200,6 +200,13 @@ def app(config: Config) -> FastAPI:
             database.add_chat(session, user=user, chat=chat)
             return chat
 
+    @app.get("/chat-identifiers")
+    async def get_chat_identifiers(
+        user: UserDependency
+    ) -> list[schemas.ChatIdentifier]:
+        with get_session() as session:
+            return database.get_chat_identifiers(session, user=user)
+
     @app.get("/chats")
     async def get_chats(user: UserDependency) -> list[schemas.Chat]:
         with get_session() as session:

--- a/ragna/deploy/_api/database.py
+++ b/ragna/deploy/_api/database.py
@@ -98,6 +98,23 @@ def add_chat(session: Session, *, user: str, chat: schemas.Chat) -> None:
     session.commit()
 
 
+def _orm_to_schema_identifier(chat: orm.Chat) -> schemas.ChatIdentifier:
+    return schemas.ChatIdentifier(id=chat.id, name=chat.name)
+
+
+def get_chat_identifiers(
+    session: Session, *, user: str
+) -> list[schemas.ChatIdentifier]:
+    return [
+        _orm_to_schema_identifier(chat)
+        for chat in session.execute(
+            select(orm.Chat).where(orm.Chat.user_id == _get_user_id(session, user))
+        )
+        .scalars()
+        .all()
+    ]
+
+
 def _orm_to_schema_chat(chat: orm.Chat) -> schemas.Chat:
     documents = [
         schemas.Document(id=document.id, name=document.name)

--- a/ragna/deploy/_api/schemas.py
+++ b/ragna/deploy/_api/schemas.py
@@ -82,3 +82,8 @@ class Chat(BaseModel):
     metadata: ChatMetadata
     messages: list[Message] = Field(default_factory=list)
     prepared: bool = False
+
+
+class ChatIdentifier(BaseModel):
+    id: uuid.UUID
+    name: str


### PR DESCRIPTION
This PR adds an endpoint that returns a list of mappings from chat UUID to chat name for all chats that a user has created. This is useful when a user would like to perform actions on specific historical chats. 

Currently, the only way to get this information is to make a request for all previous chat information (includes messages, sources etc). This can be impractical when building UIs for users with a large amount of previous chats.