### PR TITLE
fix doc links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ Check out the Ragna documentation to get started:
 
 - [Installation steps](https://ragna.chat/en/stable/install/)
 - Tutorials
-  - [Python API](https://ragna.chat/en/stable/tutorials/python-api/)
-  - [REST API](https://ragna.chat/en/stable/tutorials/rest-api/)
-  - [Web application](https://ragna.chat/en/stable/tutorials/web-app/)
+  - [Python API](https://ragna.chat/en/stable/generated/tutorials/gallery_python_api/)
+  - [REST API](https://ragna.chat/en/stable/generated/tutorials/gallery_rest_api/)
+  - [Web application](https://ragna.chat/en/stable/generated/tutorials/gallery_web_ui/)
 - [Frequently asked questions](https://ragna.chat/en/stable/references/faq/)
 - [Contribution guidelines](https://ragna.chat/en/stable/community/contribute/)
-- [Changelog](https://ragna.chat/en/stable/references/changelog/)
+- [Release notes](https://ragna.chat/en/stable/references/release-notes/)
 
 ## Code of Conduct 📜
 


### PR DESCRIPTION
Follow-up to #89 and #309. These links are broken as of now, since they point to the stable documentation, which will only include the resources after the 0.2.0 release.