### PR TITLE
use root_path in api.url

### DIFF
--- a/docs/references/config.md
+++ b/docs/references/config.md
@@ -90,9 +90,15 @@ Hostname the REST API will be bound to.
 
 Port the REST API will be bound to.
 
+#### `root_path`
+
+A path prefix handled by a proxy that is not seen by the REST API, but is seen by
+external clients.
+
 #### `url`
 
-URL of the REST API to be accessed by the web UI.
+URL of the REST API to be accessed by the web UI. Make sure to include the
+[`root_path`](#root_path) if set.
 
 #### `origins`
 
@@ -104,11 +110,6 @@ to connect to the REST API. The URL of the web UI is required for it to function
 URL of a SQL database that will be used to store the Ragna state. See
 [SQLAlchemy documentation](https://docs.sqlalchemy.org/en/20/core/engines.html#database-urls)
 on how to format the URL.
-
-#### `root_path`
-
-A path prefix handled by a proxy that is not seen by the REST API, but is seen by
-external clients.
 
 ### `ui`
 

--- a/docs/references/release-notes.md
+++ b/docs/references/release-notes.md
@@ -113,12 +113,12 @@
   [api]
   hostname = "127.0.0.1"
   port = 31476
+  root_path = ""
   url = "http://127.0.0.1:31476"
   origins = [
       "http://127.0.0.1:31477",
   ]
   database_url = "sqlite://"
-  root_path = ""
 
   [ui]
   hostname = "127.0.0.1"

--- a/ragna-docker.toml
+++ b/ragna-docker.toml
@@ -13,10 +13,10 @@ assistants = [
 [api]
 hostname = "0.0.0.0"
 port = 31476
+root_path = ""
 url = "http://localhost:31476"
 origins = ["http://localhost:31477"]
 database_url = "sqlite:////var/ragna/ragna.db"
-root_path = ""
 
 [ui]
 hostname = "0.0.0.0"

--- a/ragna/deploy/_config.py
+++ b/ragna/deploy/_config.py
@@ -112,14 +112,14 @@ class ApiConfig(ConfigBase):
 
     hostname: str = "127.0.0.1"
     port: int = 31476
+    root_path: str = ""
     url: str = AfterConfigValidateDefault.make(
-        lambda config: f"http://{config.api.hostname}:{config.api.port}",
+        lambda config: f"http://{config.api.hostname}:{config.api.port}{config.api.root_path}",
     )
-    origins: list[str] = AfterConfigValidateDefault.make(make_default_origins)
     database_url: str = AfterConfigValidateDefault.make(
         lambda config: f"sqlite:///{config.local_root}/ragna.db",
     )
-    root_path: str = ""
+    origins: list[str] = AfterConfigValidateDefault.make(make_default_origins)
 
 
 class UiConfig(ConfigBase):


### PR DESCRIPTION
Supersedes #305. After an offline discussion with @aktech we agreed that it preferable to include the `config.api.root_path` in `config.api.url`. While this means we have this we have this information duplicated in the default configuration, this has two upsides:

1. We don't need to join the URL and the root path everywhere in our code base.
2. It opens up the possibility to route an app deployed with a root path to a top level domain without one.