### PR TITLE
add test for a streaming assistant

### DIFF
--- a/tests/deploy/api/test_e2e.py
+++ b/tests/deploy/api/test_e2e.py
@@ -37,6 +37,12 @@ def test_e2e(tmp_local_root, multiple_answer_chunks, stream_answer):
     with open(document_path, "w") as file:
         file.write("!\n")
 
+    # Reset starlette_sse AppStatus for each run
+    # See https://github.com/sysid/sse-starlette/issues/59
+    from sse_starlette.sse import AppStatus
+
+    AppStatus.should_exit_event = None
+
     with TestClient(app(config=config, ignore_unavailable_components=False)) as client:
         authenticate(client)
 

--- a/tests/deploy/api/test_e2e.py
+++ b/tests/deploy/api/test_e2e.py
@@ -112,6 +112,7 @@ def test_e2e(tmp_local_root, multiple_answer_chunks, stream_answer):
                 for sse in event_source.iter_sse():
                     chunks.append(json.loads(sse.data))
             message = chunks[0]
+            assert all(chunk["sources"] is None for chunk in chunks[1:])
             message["content"] = "".join(chunk["content"] for chunk in chunks)
         else:
             message = (


### PR DESCRIPTION
Previously, we indeed tested `stream=True`, but we used the demo assistant to do it which does not support streaming. Meaning, we only ever got a single chunk from the API.

Test for this was proposed in https://github.com/Quansight/ragna/pull/317#pullrequestreview-1886007856.