### PR TITLE
improve error handling for builtin assistants

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -9,6 +9,7 @@ dependencies:
       - python-dotenv
       - pytest >=6
       - pytest-mock
+      - pytest-asyncio
       - mypy ==1.6.1
       - pre-commit
       - types-aiofiles

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ ignore = ["E501"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "-ra --tb=short"
+addopts = "-ra --tb=short --asyncio-mode=auto"
 testpaths = [
     "tests",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,10 +103,11 @@ testpaths = [
 ]
 filterwarnings = [
     "error",
+    "ignore::ResourceWarning",
     # httpx 0.27.0 deprecated some functionality that the test client of starlette /
     # FastApi use. This should be resolved by the next release of these libraries.
     # See https://github.com/encode/starlette/issues/2524
-    "ignore:The 'app' shortcut is now deprecated:DeprecationWarning"
+    "ignore:The 'app' shortcut is now deprecated:DeprecationWarning",
 ]
 xfail_strict = true
 

--- a/ragna/assistants/_ai21labs.py
+++ b/ragna/assistants/_ai21labs.py
@@ -1,6 +1,6 @@
 from typing import AsyncIterator, cast
 
-from ragna.core import RagnaException, Source
+from ragna.core import Source
 
 from ._api import ApiAssistant
 
@@ -53,11 +53,7 @@ class Ai21LabsAssistant(ApiAssistant):
                 "system": self._make_system_content(sources),
             },
         )
-
-        if response.is_error:
-            raise RagnaException(
-                status_code=response.status_code, response=response.json()
-            )
+        await self._assert_api_call_is_success(response)
 
         yield cast(str, response.json()["outputs"][0]["text"])
 

--- a/ragna/assistants/_anthropic.py
+++ b/ragna/assistants/_anthropic.py
@@ -53,6 +53,8 @@ class AnthropicApiAssistant(ApiAssistant):
                 "stream": True,
             },
         ) as event_source:
+            await self._assert_api_call_is_success(event_source.response)
+
             async for sse in event_source.aiter_sse():
                 data = json.loads(sse.data)
                 if data["type"] != "completion":

--- a/ragna/assistants/_api.py
+++ b/ragna/assistants/_api.py
@@ -1,11 +1,14 @@
 import abc
+import contextlib
+import json
 import os
 from typing import AsyncIterator
 
 import httpx
+from httpx import Response
 
 import ragna
-from ragna.core import Assistant, EnvVarRequirement, Requirement, Source
+from ragna.core import Assistant, EnvVarRequirement, RagnaException, Requirement, Source
 
 
 class ApiAssistant(Assistant):
@@ -35,3 +38,19 @@ class ApiAssistant(Assistant):
         self, prompt: str, sources: list[Source], *, max_new_tokens: int
     ) -> AsyncIterator[str]:
         ...
+
+    async def _assert_api_call_is_success(self, response: Response) -> None:
+        if response.is_success:
+            return
+
+        content = await response.aread()
+        with contextlib.suppress(Exception):
+            content = json.loads(content)
+
+        raise RagnaException(
+            "API call failed",
+            request_method=response.request.method,
+            request_url=str(response.request.url),
+            response_status_code=response.status_code,
+            response_content=content,
+        )

--- a/ragna/assistants/_cohere.py
+++ b/ragna/assistants/_cohere.py
@@ -1,7 +1,7 @@
 import json
 from typing import AsyncIterator, cast
 
-from ragna.core import RagnaException, Source
+from ragna.core import Source
 
 from ._api import ApiAssistant
 
@@ -54,8 +54,8 @@ class CohereApiAssistant(ApiAssistant):
                 "documents": self._make_source_documents(sources),
             },
         ) as response:
-            if response.is_error:
-                raise RagnaException(status_code=response.status_code)
+            await self._assert_api_call_is_success(response)
+
             async for chunk in response.aiter_lines():
                 event = json.loads(chunk)
                 if event["event_type"] == "stream-end":

--- a/ragna/assistants/_cohere.py
+++ b/ragna/assistants/_cohere.py
@@ -1,7 +1,7 @@
 import json
 from typing import AsyncIterator, cast
 
-from ragna.core import Source
+from ragna.core import RagnaException, Source
 
 from ._api import ApiAssistant
 
@@ -59,7 +59,10 @@ class CohereApiAssistant(ApiAssistant):
             async for chunk in response.aiter_lines():
                 event = json.loads(chunk)
                 if event["event_type"] == "stream-end":
-                    break
+                    if event["event_type"] == "COMPLETE":
+                        break
+
+                    raise RagnaException(event["error_message"])
                 if "text" in event:
                     yield cast(str, event["text"])
 

--- a/ragna/assistants/_google.py
+++ b/ragna/assistants/_google.py
@@ -87,6 +87,8 @@ class GoogleApiAssistant(ApiAssistant):
                 },
             },
         ) as response:
+            await self._assert_api_call_is_success(response)
+
             async for chunk in ijson.items(
                 AsyncIteratorReader(response.aiter_bytes(1024)),
                 "item.candidates.item.content.parts.item.text",

--- a/ragna/assistants/_mosaicml.py
+++ b/ragna/assistants/_mosaicml.py
@@ -1,6 +1,6 @@
 from typing import AsyncIterator, cast
 
-from ragna.core import RagnaException, Source
+from ragna.core import Source
 
 from ._api import ApiAssistant
 
@@ -43,10 +43,8 @@ class MosaicmlApiAssistant(ApiAssistant):
                 "parameters": {"temperature": 0.0, "max_new_tokens": max_new_tokens},
             },
         )
-        if response.is_error:
-            raise RagnaException(
-                status_code=response.status_code, response=response.json()
-            )
+        await self._assert_api_call_is_success(response)
+
         yield cast(str, response.json()["outputs"][0]).replace(instruction, "").strip()
 
 

--- a/ragna/assistants/_openai.py
+++ b/ragna/assistants/_openai.py
@@ -60,6 +60,8 @@ class OpenaiApiAssistant(ApiAssistant):
                 "stream": True,
             },
         ) as event_source:
+            await self._assert_api_call_is_success(event_source.response)
+
             async for sse in event_source.aiter_sse():
                 data = json.loads(sse.data)
                 choice = data["choices"][0]

--- a/tests/assistants/test_api.py
+++ b/tests/assistants/test_api.py
@@ -6,6 +6,7 @@ from ragna import assistants
 from ragna._compat import anext
 from ragna.assistants._api import ApiAssistant
 from ragna.core import RagnaException
+from tests.utils import skip_on_windows
 
 API_ASSISTANTS = [
     assistant
@@ -16,6 +17,7 @@ API_ASSISTANTS = [
 ]
 
 
+@skip_on_windows
 @pytest.mark.parametrize("assistant", API_ASSISTANTS)
 async def test_api_call_error_smoke(mocker, assistant):
     mocker.patch.dict(os.environ, {assistant._API_KEY_ENV_VAR: "SENTINEL"})

--- a/tests/assistants/test_api.py
+++ b/tests/assistants/test_api.py
@@ -1,0 +1,30 @@
+import asyncio
+import os
+
+import pytest
+
+from ragna import assistants
+from ragna.core import RagnaException
+
+API_ASSISTANTS = [
+    assistant
+    for assistant in assistants.__dict__.values()
+    if isinstance(assistant, type)
+    and issubclass(assistant, assistants._api.ApiAssistant)
+    and assistant is not assistants._api.ApiAssistant
+]
+
+
+@pytest.mark.parametrize("assistant_cls", API_ASSISTANTS)
+def test_api_call_error_smoke(mocker, assistant_cls):
+    mocker.patch.dict(os.environ, {assistant_cls._API_KEY_ENV_VAR: "SENTINEL"})
+
+    assistant = assistant_cls()
+
+    async def run():
+        return "".join(
+            [chunk async for chunk in assistant.answer(prompt="?", sources=[])]
+        )
+
+    with pytest.raises(RagnaException, match="API call failed"):
+        asyncio.run(run())

--- a/tests/assistants/test_api.py
+++ b/tests/assistants/test_api.py
@@ -1,30 +1,26 @@
-import asyncio
 import os
 
 import pytest
 
 from ragna import assistants
+from ragna._compat import anext
+from ragna.assistants._api import ApiAssistant
 from ragna.core import RagnaException
 
 API_ASSISTANTS = [
     assistant
     for assistant in assistants.__dict__.values()
     if isinstance(assistant, type)
-    and issubclass(assistant, assistants._api.ApiAssistant)
-    and assistant is not assistants._api.ApiAssistant
+    and issubclass(assistant, ApiAssistant)
+    and assistant is not ApiAssistant
 ]
 
 
-@pytest.mark.parametrize("assistant_cls", API_ASSISTANTS)
-def test_api_call_error_smoke(mocker, assistant_cls):
-    mocker.patch.dict(os.environ, {assistant_cls._API_KEY_ENV_VAR: "SENTINEL"})
+@pytest.mark.parametrize("assistant", API_ASSISTANTS)
+async def test_api_call_error_smoke(mocker, assistant):
+    mocker.patch.dict(os.environ, {assistant._API_KEY_ENV_VAR: "SENTINEL"})
 
-    assistant = assistant_cls()
-
-    async def run():
-        return "".join(
-            [chunk async for chunk in assistant.answer(prompt="?", sources=[])]
-        )
+    chunks = assistant().answer(prompt="?", sources=[])
 
     with pytest.raises(RagnaException, match="API call failed"):
-        asyncio.run(run())
+        await anext(chunks)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,3 @@
-import asyncio
-import platform
-
 import pytest
 
 import ragna
@@ -13,10 +10,3 @@ def tmp_local_root(tmp_path):
         yield ragna.local_root(tmp_path)
     finally:
         ragna.local_root(old)
-
-
-@pytest.fixture(scope="session", autouse=True)
-def windows_event_loop_policy():
-    # See https://stackoverflow.com/a/66772242
-    if platform.system() == "Windows":
-        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+import asyncio
+import platform
+
 import pytest
 
 import ragna
@@ -10,3 +13,10 @@ def tmp_local_root(tmp_path):
         yield ragna.local_root(tmp_path)
     finally:
         ragna.local_root(old)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def windows_event_loop_policy():
+    # See https://stackoverflow.com/a/66772242
+    if platform.system() == "Windows":
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,4 +2,6 @@ import platform
 
 import pytest
 
-skip_on_windows = pytest.mark.skipif(platform.system() == "Windows")
+skip_on_windows = pytest.mark.skipif(
+    platform.system() == "Windows", reason="Test is broken skipped on Windows"
+)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,5 @@
+import platform
+
+import pytest
+
+skip_on_windows = pytest.mark.skipif(platform.system() == "Windows")


### PR DESCRIPTION
I spend almost an hour today trying to find a bug that wasn't there, because we didn't raise a proper error when our API call failed.