### PR TITLE
decrease default number of tokens in UI

### DIFF
--- a/ragna/deploy/_ui/modal_configuration.py
+++ b/ragna/deploy/_ui/modal_configuration.py
@@ -36,7 +36,7 @@ class ChatConfig(param.Parameterized):
     max_context_tokens = param.Integer(
         step=500,
         bounds=(1, 8000),
-        default=4000,
+        default=2000,
         doc=(
             "Maximum number of context tokens and in turn the number of document chunks "
             "pulled out of the vector database."


### PR DESCRIPTION
This is a temporary fix for the Cohere assistants. Although in theory they support a 4k context window

https://github.com/Quansight/ragna/blob/8b0b0f3871b4f5929d1d02f9dd6aada06c4f3f67/ragna/assistants/_cohere.py#L12-L13

they seem to be using a very different tokenizer than what we use. When trying the assistant in the web UI with a document that actually supply 4k tokens, I get the following error message in the response

```
too many tokens: size limit exceeded by 1502 tokens. Try using shorter or fewer inputs, or setting prompt_truncation='AUTO'.
```

So the number of tokens actually differs by almost 40%.

In this PR I simply reduce the default number of tokens that we pull from the source storage to feed into the assistant. Setting this automatically depending on the assistant is a larger task that I'll open an issue about. Plus, the tokenizer would actually need to be dependent on the assistant as well.

Functionally, this change should make too much of a difference. Unless the user has a very complex query, by default we are still going to pull in four sources. That should be sufficient.