### PR TITLE
fix release notes link in project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dynamic = ["version"]
 [project.urls]
 Homepage = "https://ragna.chat"
 Documentation = "https://ragna.chat"
-Changelog = "https://ragna.chat/en/latest/references/changelog/"
+Changelog = "https://ragna.chat/en/stable/references/release-notes/"
 Repository = "https://github.com/Quansight/ragna"
 
 [project.optional-dependencies]


### PR DESCRIPTION
1. We renamed the file.
2. We should point at the release notes of the current stable release rather than the dev version.