### PR TITLE
remove max_input_size property from assistants

### DIFF
--- a/docs/examples/gallery_streaming.py
+++ b/docs/examples/gallery_streaming.py
@@ -43,10 +43,6 @@ from ragna import assistants
 
 
 class DemoStreamingAssistant(assistants.RagnaDemoAssistant):
-    @property
-    def max_input_size(self) -> int:
-        return 0
-
     def answer(self, prompt, sources):
         content = next(super().answer(prompt, sources))
         for chunk in content.split(" "):

--- a/docs/references/release-notes.md
+++ b/docs/references/release-notes.md
@@ -39,6 +39,9 @@
 - The return type of [ragna.core.Assistant.answer][] changed from `str` to
   `Iterator[str]` / `AsyncIterator[str]`. To reflect that in the implementation, replace
   `return` with `yield`. To stream the response, `yield` multiple times.
+- The abstract property `ragna.core.Assistant.max_input_size` was removed. This
+  information was never used anywhere. Note that you don't have to remove it from
+  existing implementations. It will just stay unused by Ragna.
 - We introduced a couple of changes to the configuration file.
 
   - The top level `local_cache_root` option was renamed to `local_root` to align with

--- a/ragna/assistants/_ai21labs.py
+++ b/ragna/assistants/_ai21labs.py
@@ -8,16 +8,10 @@ from ._api import ApiAssistant
 class Ai21LabsAssistant(ApiAssistant):
     _API_KEY_ENV_VAR = "AI21_API_KEY"
     _MODEL_TYPE: str
-    _CONTEXT_SIZE: int = 8_192
-    # See https://docs.ai21.com/docs/model-availability-across-platforms#ai21-studio
 
     @classmethod
     def display_name(cls) -> str:
         return f"AI21Labs/jurassic-2-{cls._MODEL_TYPE}"
-
-    @property
-    def max_input_size(self) -> int:
-        return self._CONTEXT_SIZE
 
     def _make_system_content(self, sources: list[Source]) -> str:
         instruction = (

--- a/ragna/assistants/_anthropic.py
+++ b/ragna/assistants/_anthropic.py
@@ -11,15 +11,10 @@ from ._api import ApiAssistant
 class AnthropicApiAssistant(ApiAssistant):
     _API_KEY_ENV_VAR = "ANTHROPIC_API_KEY"
     _MODEL: str
-    _CONTEXT_SIZE: int
 
     @classmethod
     def display_name(cls) -> str:
         return f"Anthropic/{cls._MODEL}"
-
-    @property
-    def max_input_size(self) -> int:
-        return self._CONTEXT_SIZE
 
     def _instructize_prompt(self, prompt: str, sources: list[Source]) -> str:
         # See https://docs.anthropic.com/claude/docs/introduction-to-prompt-design#human--assistant-formatting
@@ -76,7 +71,6 @@ class ClaudeInstant(AnthropicApiAssistant):
     """
 
     _MODEL = "claude-instant-1"
-    _CONTEXT_SIZE = 100_000
 
 
 class Claude(AnthropicApiAssistant):
@@ -88,4 +82,3 @@ class Claude(AnthropicApiAssistant):
     """
 
     _MODEL = "claude-2"
-    _CONTEXT_SIZE = 100_000

--- a/ragna/assistants/_cohere.py
+++ b/ragna/assistants/_cohere.py
@@ -9,16 +9,10 @@ from ._api import ApiAssistant
 class CohereApiAssistant(ApiAssistant):
     _API_KEY_ENV_VAR = "COHERE_API_KEY"
     _MODEL: str
-    _CONTEXT_SIZE: int = 4_000
-    # See https://docs.cohere.com/docs/models#command
 
     @classmethod
     def display_name(cls) -> str:
         return f"Cohere/{cls._MODEL}"
-
-    @property
-    def max_input_size(self) -> int:
-        return self._CONTEXT_SIZE
 
     def _make_preamble(self) -> str:
         return (

--- a/ragna/assistants/_demo.py
+++ b/ragna/assistants/_demo.py
@@ -1,5 +1,4 @@
 import re
-import sys
 import textwrap
 from typing import Iterator
 
@@ -22,10 +21,6 @@ class RagnaDemoAssistant(Assistant):
     @classmethod
     def display_name(cls) -> str:
         return "Ragna/DemoAssistant"
-
-    @property
-    def max_input_size(self) -> int:
-        return sys.maxsize
 
     def answer(self, prompt: str, sources: list[Source]) -> Iterator[str]:
         if re.search("markdown", prompt, re.IGNORECASE):

--- a/ragna/assistants/_google.py
+++ b/ragna/assistants/_google.py
@@ -28,7 +28,6 @@ class AsyncIteratorReader:
 class GoogleApiAssistant(ApiAssistant):
     _API_KEY_ENV_VAR = "GOOGLE_API_KEY"
     _MODEL: str
-    _CONTEXT_SIZE: int
 
     @classmethod
     def requirements(cls) -> list[Requirement]:
@@ -40,10 +39,6 @@ class GoogleApiAssistant(ApiAssistant):
     @classmethod
     def display_name(cls) -> str:
         return f"Google/{cls._MODEL}"
-
-    @property
-    def max_input_size(self) -> int:
-        return self._CONTEXT_SIZE
 
     def _instructize_prompt(self, prompt: str, sources: list[Source]) -> str:
         # https://ai.google.dev/docs/prompt_best_practices#add-contextual-information
@@ -109,7 +104,6 @@ class GeminiPro(GoogleApiAssistant):
     """
 
     _MODEL = "gemini-pro"
-    _CONTEXT_SIZE = 30_720
 
 
 class GeminiUltra(GoogleApiAssistant):
@@ -125,4 +119,3 @@ class GeminiUltra(GoogleApiAssistant):
     """
 
     _MODEL = "gemini-ultra"
-    _CONTEXT_SIZE = 30_720

--- a/ragna/assistants/_mosaicml.py
+++ b/ragna/assistants/_mosaicml.py
@@ -8,15 +8,10 @@ from ._api import ApiAssistant
 class MosaicmlApiAssistant(ApiAssistant):
     _API_KEY_ENV_VAR = "MOSAICML_API_KEY"
     _MODEL: str
-    _CONTEXT_SIZE: int
 
     @classmethod
     def display_name(cls) -> str:
         return f"MosaicML/{cls._MODEL}"
-
-    @property
-    def max_input_size(self) -> int:
-        return self._CONTEXT_SIZE
 
     def _instructize_prompt(self, prompt: str, sources: list[Source]) -> str:
         # See https://huggingface.co/mosaicml/mpt-7b-instruct#formatting
@@ -58,7 +53,6 @@ class Mpt7bInstruct(MosaicmlApiAssistant):
 
     # https://huggingface.co/mosaicml/mpt-7b-instruct#model-description
     _MODEL = "mpt-7b-instruct"
-    _CONTEXT_SIZE = 2048
 
 
 class Mpt30bInstruct(MosaicmlApiAssistant):
@@ -71,4 +65,3 @@ class Mpt30bInstruct(MosaicmlApiAssistant):
 
     # https://huggingface.co/mosaicml/mpt-30b-instruct#model-description
     _MODEL = "mpt-30b-instruct"
-    _CONTEXT_SIZE = 8_192

--- a/ragna/assistants/_openai.py
+++ b/ragna/assistants/_openai.py
@@ -11,15 +11,10 @@ from ._api import ApiAssistant
 class OpenaiApiAssistant(ApiAssistant):
     _API_KEY_ENV_VAR = "OPENAI_API_KEY"
     _MODEL: str
-    _CONTEXT_SIZE: int
 
     @classmethod
     def display_name(cls) -> str:
         return f"OpenAI/{cls._MODEL}"
-
-    @property
-    def max_input_size(self) -> int:
-        return self._CONTEXT_SIZE
 
     def _make_system_content(self, sources: list[Source]) -> str:
         # See https://github.com/openai/openai-cookbook/blob/main/examples/How_to_format_inputs_to_ChatGPT_models.ipynb
@@ -80,7 +75,6 @@ class Gpt35Turbo16k(OpenaiApiAssistant):
     """
 
     _MODEL = "gpt-3.5-turbo-16k"
-    _CONTEXT_SIZE = 16_384
 
 
 class Gpt4(OpenaiApiAssistant):
@@ -92,4 +86,3 @@ class Gpt4(OpenaiApiAssistant):
     """
 
     _MODEL = "gpt-4"
-    _CONTEXT_SIZE = 8_192

--- a/ragna/core/_components.py
+++ b/ragna/core/_components.py
@@ -212,11 +212,6 @@ class Assistant(Component, abc.ABC):
 
     __ragna_protocol_methods__ = ["answer"]
 
-    @property
-    @abc.abstractmethod
-    def max_input_size(self) -> int:
-        ...
-
     @abc.abstractmethod
     def answer(self, prompt: str, sources: list[Source]) -> Iterator[str]:
         """Answer a prompt given some sources.

--- a/tests/deploy/api/test_e2e.py
+++ b/tests/deploy/api/test_e2e.py
@@ -12,10 +12,6 @@ from .utils import authenticate
 
 
 class TestAssistant(RagnaDemoAssistant):
-    @property
-    def max_input_size(self) -> int:
-        return 0
-
     def answer(self, prompt, sources, *, multiple_answer_chunks: bool):
         content = next(super().answer(prompt, sources))
 


### PR DESCRIPTION
The abstract `Assistant.max_input_size` property was a left over from the prototype implementation we started from. The idea behind it was for to be able to automatically fill the context window, such that it is maxed out with the sources and the user prompt.

However, this makes quite a few assumptions, that held for our prototype, but are no longer true for Ragna:

- Our builtin `Chroma` and `LanceDB` have a parameter to pull a specific number of tokens
  https://github.com/Quansight/ragna/blob/4a667f9aced1970f8eab8aa9e01aaf8c67b05db0/ragna/source_storages/_chroma.py#L80
  https://github.com/Quansight/ragna/blob/4a667f9aced1970f8eab8aa9e01aaf8c67b05db0/ragna/source_storages/_lancedb.py#L94
  but our demo source storage does not
  https://github.com/Quansight/ragna/blob/4a667f9aced1970f8eab8aa9e01aaf8c67b05db0/ragna/source_storages/_demo.py#L39-L41
  Since this parameter is not part of the core protocol, we cannot make any assumptions on whether it is present or not. This holds especially for user defined source storages.
- In #297 we discuss making the chunking more flexible. We have no guarantee that user defined chunking strategies even can supply the information on how many tokens there are in the chunk that we are storing.
- Each assistant potentially uses a different tokenizer. Without this information, the number of tokens a chunking strategy would compute is meaningless. See https://github.com/Quansight/ragna/pull/351 for an example of that

Meaning, `Assistant.max_input_size` is not only unused, actually using it requires a major effort in designing a proper interface. And with all that uncertainty I'd rather not force users to implement this property.

Note that this is only mildly BC breaking. Users that had defined this property on their custom assistants are untouched by this change. It just stays unused. Only if you access this property on our builtin assistants, you will have a breakage.