### PR TITLE
fix docker tag in release notes

### DIFF
--- a/docs/references/release-notes.md
+++ b/docs/references/release-notes.md
@@ -23,7 +23,7 @@
 - Ragna now has an official [docker](https://www.docker.com/) image. Try it with
 
   ```
-  $ docker run -p 31476:31476 -p 31477:31477 quay.io/quansight/ragna:latest
+  $ docker run -p 31476:31476 -p 31477:31477 quay.io/quansight/ragna:0.2.0
   ```
 
   The web UI can be accessed under `http://localhost:31477`.


### PR DESCRIPTION
Our current pipeline is not set up to push a `latest` tag

https://github.com/Quansight/ragna/blob/5a9bdf69de6b4234831532c0d13797a7015a61bf/.github/workflows/docker.yml#L67-L77

Will fix that after release given that latest is a meta tag anyway.