### PR TITLE
Refactor `ApiAssistant` to `AuthenticatedApiAssistant` and `UnauthenticatedApiAssistant`

### DIFF
--- a/ragna/assistants/_ai21labs.py
+++ b/ragna/assistants/_ai21labs.py
@@ -2,10 +2,10 @@ from typing import AsyncIterator, cast
 
 from ragna.core import Source
 
-from ._api import ApiAssistant
+from ._api import AuthenticatedApiAssistant
 
 
-class Ai21LabsAssistant(ApiAssistant):
+class Ai21LabsAssistant(AuthenticatedApiAssistant):
     _API_KEY_ENV_VAR = "AI21_API_KEY"
     _MODEL_TYPE: str
 

--- a/ragna/assistants/_anthropic.py
+++ b/ragna/assistants/_anthropic.py
@@ -3,10 +3,10 @@ from typing import AsyncIterator, cast
 
 from ragna.core import PackageRequirement, RagnaException, Requirement, Source
 
-from ._api import ApiAssistant
+from ._api import AuthenticatedApiAssistant
 
 
-class AnthropicApiAssistant(ApiAssistant):
+class AnthropicApiAssistant(AuthenticatedApiAssistant):
     _API_KEY_ENV_VAR = "ANTHROPIC_API_KEY"
     _MODEL: str
 

--- a/ragna/assistants/_api.py
+++ b/ragna/assistants/_api.py
@@ -1,7 +1,6 @@
 import abc
 import contextlib
 import json
-import os
 from typing import AsyncIterator
 
 import httpx
@@ -12,11 +11,9 @@ from ragna.core import Assistant, EnvVarRequirement, RagnaException, Requirement
 
 
 class ApiAssistant(Assistant):
-    _API_KEY_ENV_VAR: str
-
     @classmethod
     def requirements(cls) -> list[Requirement]:
-        return [EnvVarRequirement(cls._API_KEY_ENV_VAR), *cls._extra_requirements()]
+        return []
 
     @classmethod
     def _extra_requirements(cls) -> list[Requirement]:
@@ -27,7 +24,6 @@ class ApiAssistant(Assistant):
             headers={"User-Agent": f"{ragna.__version__}/{self}"},
             timeout=60,
         )
-        self._api_key = os.environ[self._API_KEY_ENV_VAR]
 
     async def answer(
         self, prompt: str, sources: list[Source], *, max_new_tokens: int = 256
@@ -58,3 +54,11 @@ class ApiAssistant(Assistant):
             response_status_code=response.status_code,
             response_content=content,
         )
+
+
+class AuthenticatedApiAssistant(ApiAssistant):
+    _API_KEY_ENV_VAR: str
+
+    @classmethod
+    def requirements(cls) -> list[Requirement]:
+        return [EnvVarRequirement(cls._API_KEY_ENV_VAR), *cls._extra_requirements()]

--- a/ragna/assistants/_api.py
+++ b/ragna/assistants/_api.py
@@ -11,7 +11,7 @@ import ragna
 from ragna.core import Assistant, EnvVarRequirement, RagnaException, Requirement, Source
 
 
-class ApiAssistant(Assistant):
+class _ApiAssistant(Assistant):
     @classmethod
     def requirements(cls) -> list[Requirement]:
         return []
@@ -57,7 +57,7 @@ class ApiAssistant(Assistant):
         )
 
 
-class AuthenticatedApiAssistant(ApiAssistant):
+class AuthenticatedApiAssistant(_ApiAssistant):
     _API_KEY_ENV_VAR: str
 
     @classmethod

--- a/ragna/assistants/_api.py
+++ b/ragna/assistants/_api.py
@@ -67,3 +67,8 @@ class AuthenticatedApiAssistant(_ApiAssistant):
     def __init__(self) -> None:
         super().__init__()
         self._api_key = os.environ[self._API_KEY_ENV_VAR]
+
+
+class UnauthenticatedApiAssistant(_ApiAssistant):
+    def __init__(self) -> None:
+        super().__init__()

--- a/ragna/assistants/_api.py
+++ b/ragna/assistants/_api.py
@@ -1,6 +1,7 @@
 import abc
 import contextlib
 import json
+import os
 from typing import AsyncIterator
 
 import httpx
@@ -62,3 +63,7 @@ class AuthenticatedApiAssistant(ApiAssistant):
     @classmethod
     def requirements(cls) -> list[Requirement]:
         return [EnvVarRequirement(cls._API_KEY_ENV_VAR), *cls._extra_requirements()]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._api_key = os.environ[self._API_KEY_ENV_VAR]

--- a/ragna/assistants/_cohere.py
+++ b/ragna/assistants/_cohere.py
@@ -3,10 +3,10 @@ from typing import AsyncIterator, cast
 
 from ragna.core import RagnaException, Source
 
-from ._api import ApiAssistant
+from ._api import AuthenticatedApiAssistant
 
 
-class CohereApiAssistant(ApiAssistant):
+class CohereApiAssistant(AuthenticatedApiAssistant):
     _API_KEY_ENV_VAR = "COHERE_API_KEY"
     _MODEL: str
 

--- a/ragna/assistants/_google.py
+++ b/ragna/assistants/_google.py
@@ -3,7 +3,7 @@ from typing import AsyncIterator
 from ragna._compat import anext
 from ragna.core import PackageRequirement, Requirement, Source
 
-from ._api import ApiAssistant
+from ._api import AuthenticatedApiAssistant
 
 
 # ijson does not support reading from an (async) iterator, but only from file-like
@@ -25,7 +25,7 @@ class AsyncIteratorReader:
         return await anext(self._ait, b"")  # type: ignore[call-arg]
 
 
-class GoogleApiAssistant(ApiAssistant):
+class GoogleApiAssistant(AuthenticatedApiAssistant):
     _API_KEY_ENV_VAR = "GOOGLE_API_KEY"
     _MODEL: str
 

--- a/ragna/assistants/_mosaicml.py
+++ b/ragna/assistants/_mosaicml.py
@@ -2,10 +2,10 @@ from typing import AsyncIterator, cast
 
 from ragna.core import Source
 
-from ._api import ApiAssistant
+from ._api import AuthenticatedApiAssistant
 
 
-class MosaicmlApiAssistant(ApiAssistant):
+class MosaicmlApiAssistant(AuthenticatedApiAssistant):
     _API_KEY_ENV_VAR = "MOSAICML_API_KEY"
     _MODEL: str
 

--- a/ragna/assistants/_openai.py
+++ b/ragna/assistants/_openai.py
@@ -3,10 +3,10 @@ from typing import AsyncIterator, cast
 
 from ragna.core import PackageRequirement, Requirement, Source
 
-from ._api import ApiAssistant
+from ._api import AuthenticatedApiAssistant
 
 
-class OpenaiApiAssistant(ApiAssistant):
+class OpenaiApiAssistant(AuthenticatedApiAssistant):
     _API_KEY_ENV_VAR = "OPENAI_API_KEY"
     _MODEL: str
 

--- a/tests/assistants/test_api.py
+++ b/tests/assistants/test_api.py
@@ -4,7 +4,7 @@ import pytest
 
 from ragna import assistants
 from ragna._compat import anext
-from ragna.assistants._api import ApiAssistant
+from ragna.assistants._api import AuthenticatedApiAssistant, _ApiAssistant
 from ragna.core import RagnaException
 from tests.utils import skip_on_windows
 
@@ -12,8 +12,9 @@ API_ASSISTANTS = [
     assistant
     for assistant in assistants.__dict__.values()
     if isinstance(assistant, type)
-    and issubclass(assistant, ApiAssistant)
-    and assistant is not ApiAssistant
+    and issubclass(assistant, _ApiAssistant)
+    and assistant is not _ApiAssistant
+    and assistant is not AuthenticatedApiAssistant
 ]
 
 

--- a/tests/assistants/test_api.py
+++ b/tests/assistants/test_api.py
@@ -4,7 +4,11 @@ import pytest
 
 from ragna import assistants
 from ragna._compat import anext
-from ragna.assistants._api import AuthenticatedApiAssistant, _ApiAssistant
+from ragna.assistants._api import (
+    AuthenticatedApiAssistant,
+    UnauthenticatedApiAssistant,
+    _ApiAssistant,
+)
 from ragna.core import RagnaException
 from tests.utils import skip_on_windows
 
@@ -15,6 +19,7 @@ API_ASSISTANTS = [
     and issubclass(assistant, _ApiAssistant)
     and assistant is not _ApiAssistant
     and assistant is not AuthenticatedApiAssistant
+    and assistant is not UnauthenticatedApiAssistant
 ]
 
 


### PR DESCRIPTION
In preparation for adding local assistants that do not require API keys, this PR refactors `ragna.assistants._api.ApiAssistant`. 

This resolves Issue #375. 

If anyone has strong opinions about the chosen naming conventions, please share them. 

IMPORTANT: This PR should be merged after PR #380 is merged and before PR #376 is merged. 