### PR TITLE
fix mypy after pydantic 2.7

### DIFF
--- a/ragna/deploy/_cli/config.py
+++ b/ragna/deploy/_cli/config.py
@@ -42,7 +42,7 @@ def parse_config(value: str) -> Config:
         raise typer.Exit(1)
     # This stores the original value so we can pass it on to subprocesses that we might
     # start.
-    config.__ragna_cli_config_path__ = value
+    config.__ragna_cli_config_path__ = value  # type: ignore[attr-defined]
     return config
 
 
@@ -252,13 +252,13 @@ def _wizard_common() -> Config:
     )
 
     for sub_config, title in [(config.api, "REST API"), (config.ui, "web UI")]:
-        sub_config.hostname = questionary.text(
+        sub_config.hostname = questionary.text(  # type: ignore[attr-defined]
             f"What hostname do you want to bind the the Ragna {title} to?",
             default=sub_config.hostname,  # type: ignore[attr-defined]
             qmark=QMARK,
         ).unsafe_ask()
 
-        sub_config.port = int(
+        sub_config.port = int(  # type: ignore[attr-defined]
             questionary.text(
                 f"What port do you want to bind the the Ragna {title} to?",
                 default=str(sub_config.port),  # type: ignore[attr-defined]


### PR DESCRIPTION
After the pydantic 2.7 release (April 11 2024), which gets installed in CI since we only have a lower pin

https://github.com/Quansight/ragna/blob/f7de2e947c04cd3d4e8319cc117a8f9ecfa21239/pyproject.toml#L31-L33

a few typing errors popped up, e.g. https://github.com/Quansight/ragna/actions/runs/8676481873/job/23791035320?pr=389. It seems typing on these objects was made a little tighter and now we have to ignore more dynamic stuff. Fortunately, no functional changes.
