### PR TITLE
use relative links for all images in UI

### DIFF
--- a/ragna/deploy/_ui/components/file_uploader.py
+++ b/ragna/deploy/_ui/components/file_uploader.py
@@ -141,7 +141,7 @@ class FileUploader(ReactiveHTML, Widget):  # type: ignore[misc]
             </script>
             <div id="fileUploadContainer" class="fileUploadContainer">
                 <div id="fileUploadDropArea" class="fileUploadDropArea">
-                    <img src="/imgs/cloud-upload.svg" width="24px" height="24px" />
+                    <img src="imgs/cloud-upload.svg" width="24px" height="24px" />
                     <span><b>Click to upload</b> or drag and drop.<br /></span>
                     <div id='allowedDocuments'>
                         Allowed files: ${allowed_documents_str}

--- a/ragna/deploy/_ui/left_sidebar.py
+++ b/ragna/deploy/_ui/left_sidebar.py
@@ -99,7 +99,7 @@ class LeftSidebar(pn.viewable.Viewer):
                                       }
 
                                       :host div button:before {
-                                        content: url("/imgs/chat_bubble.svg");
+                                        content: url("imgs/chat_bubble.svg");
                                         margin-right: 10px;
                                         display: inline-block;
                                       }


### PR DESCRIPTION
Most of the links were already relative, but the two in this PR were not. `/imgs/...` and `imgs/...` are equivalent when Ragna is hosted at the root path, e.g. `127.0.0.1:31477`. If that is not the case, e.g. Ragna is hosted on `127.0.0.1:31477/behind/a/proxy`, `/imgs/` still points to `127.0.0.1:31477/imgs/`, whereas `imgs/` correctly points to `127.0.0.1:31477/behind/a/proxy/imgs`.