### PR TITLE
Add instructions to install from conda-forge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A RAG orchestration framework.
          alt="PyPI" />
         </a>
 		<a href="https://anaconda.org/conda-forge/ragna">
-			<img srg="https://img.shields.io/conda/vn/conda-forge/ragna?logoColor=white&logo=conda-forge" alt="conda-forge">
+			<img src="https://img.shields.io/conda/vn/conda-forge/ragna?logoColor=white&logo=conda-forge" alt="conda-forge">
 		</a>
     </td>
     <td>

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ A RAG orchestration framework.
             <img src="https://img.shields.io/pypi/v/ragna?colorA=1F2636&colorB=DF5538"
          alt="PyPI" />
         </a>
+		<a href="https://anaconda.org/conda-forge/ragna">
+			<img srg="https://img.shields.io/conda/vn/conda-forge/ragna?logoColor=white&logo=conda-forge" alt="conda-forge">
+		</a>
     </td>
     <td>
         <a href="https://ragna.chat">

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A RAG orchestration framework.
          alt="PyPI" />
         </a>
 		<a href="https://anaconda.org/conda-forge/ragna">
-			<img src="https://img.shields.io/conda/vn/conda-forge/ragna?logoColor=white&logo=conda-forge" alt="conda-forge">
+			<img src="https://img.shields.io/conda/vn/conda-forge/ragna?colorA=1F2636&colorB=DF5538" alt="conda-forge">
 		</a>
     </td>
     <td>

--- a/docs/install.md
+++ b/docs/install.md
@@ -28,7 +28,7 @@ And, upgrade to latest versions with:
 pip install --upgrade ragna
 ```
 
-Alternatively, you can install ``ragna`` with conda from conda-forge:
+Alternatively, you can install `ragna` with conda from conda-forge:
 
 ```bash
 conda install ragna -c conda-forge

--- a/docs/install.md
+++ b/docs/install.md
@@ -28,7 +28,11 @@ And, upgrade to latest versions with:
 pip install --upgrade ragna
 ```
 
-<!-- Add conda and conda-forge if/when available -->
+Alternatively, you can install ``ragna`` with conda from conda-forge:
+
+```bash
+conda install ragna -c conda-forge
+```
 
 ## Verify your installation
 


### PR DESCRIPTION
ragna has recently been brought to conda-forge; see [this feestock](https://github.com/conda-forge/ragna-feedstock) and the [package information](https://anaconda.org/conda-forge/ragna).

This PR
- addresses a TODO in the root's readme to add installation instructions via conda
- adds a button to access find the package on conda-forge, imitating the PyPI button