### PR TITLE
Fix #399 : eager loading of Chats docs, msgs, srcs

### DIFF
--- a/ragna/deploy/_api/core.py
+++ b/ragna/deploy/_api/core.py
@@ -267,6 +267,7 @@ def app(*, config: Config, ignore_unavailable_components: bool) -> FastAPI:
             chat.messages.append(
                 schemas.Message(content=prompt, role=ragna.core.MessageRole.USER)
             )
+            print(f"answer() {chat.messages[-1].role=}, {chat.messages[-1].timestamp=}")
             core_chat = schema_to_core_chat(session, user=user, chat=chat)
 
         core_answer = await core_chat.answer(prompt, stream=stream)
@@ -298,6 +299,10 @@ def app(*, config: Config, ignore_unavailable_components: bool) -> FastAPI:
                 with get_session() as session:
                     answer.content = "".join(content_chunks)
                     chat.messages.append(answer)
+                    print(
+                        f"answer() / {stream=} {chat.messages[-1].role=}, {chat.messages[-1].timestamp=}"
+                    )
+
                     database.update_chat(session, user=user, chat=chat)
 
             async def to_jsonl(models: AsyncIterator[Any]) -> AsyncIterator[str]:
@@ -313,6 +318,10 @@ def app(*, config: Config, ignore_unavailable_components: bool) -> FastAPI:
             with get_session() as session:
                 chat.messages.append(answer)
                 database.update_chat(session, user=user, chat=chat)
+
+            print(
+                f"answer() / {stream=} {chat.messages[-1].role=}, {chat.messages[-1].timestamp=}"
+            )
 
             return answer
 

--- a/ragna/deploy/_api/core.py
+++ b/ragna/deploy/_api/core.py
@@ -298,7 +298,6 @@ def app(*, config: Config, ignore_unavailable_components: bool) -> FastAPI:
                 with get_session() as session:
                     answer.content = "".join(content_chunks)
                     chat.messages.append(answer)
-
                     database.update_chat(session, user=user, chat=chat)
 
             async def to_jsonl(models: AsyncIterator[Any]) -> AsyncIterator[str]:

--- a/ragna/deploy/_api/core.py
+++ b/ragna/deploy/_api/core.py
@@ -267,7 +267,6 @@ def app(*, config: Config, ignore_unavailable_components: bool) -> FastAPI:
             chat.messages.append(
                 schemas.Message(content=prompt, role=ragna.core.MessageRole.USER)
             )
-            print(f"answer() {chat.messages[-1].role=}, {chat.messages[-1].timestamp=}")
             core_chat = schema_to_core_chat(session, user=user, chat=chat)
 
         core_answer = await core_chat.answer(prompt, stream=stream)
@@ -299,9 +298,6 @@ def app(*, config: Config, ignore_unavailable_components: bool) -> FastAPI:
                 with get_session() as session:
                     answer.content = "".join(content_chunks)
                     chat.messages.append(answer)
-                    print(
-                        f"answer() / {stream=} {chat.messages[-1].role=}, {chat.messages[-1].timestamp=}"
-                    )
 
                     database.update_chat(session, user=user, chat=chat)
 
@@ -318,10 +314,6 @@ def app(*, config: Config, ignore_unavailable_components: bool) -> FastAPI:
             with get_session() as session:
                 chat.messages.append(answer)
                 database.update_chat(session, user=user, chat=chat)
-
-            print(
-                f"answer() / {stream=} {chat.messages[-1].role=}, {chat.messages[-1].timestamp=}"
-            )
 
             return answer
 

--- a/ragna/deploy/_api/database.py
+++ b/ragna/deploy/_api/database.py
@@ -140,7 +140,7 @@ def get_chats(session: Session, *, user: str) -> list[schemas.Chat]:
     return [
         _orm_to_schema_chat(chat)
         for chat in session.execute(
-            select(orm.Chat)
+            select(orm.Chat)  # type: ignore[attr-defined]
             .options(
                 joinedload(orm.Chat.messages).joinedload(orm.Message.sources),
                 joinedload(orm.Chat.documents),

--- a/ragna/deploy/_api/orm.py
+++ b/ragna/deploy/_api/orm.py
@@ -72,29 +72,6 @@ class Document(Base):
     )
 
 
-source_message_association_table = Table(
-    "source_message_association_table",
-    Base.metadata,
-    Column("source_id", ForeignKey("sources.id"), primary_key=True),
-    Column("message_id", ForeignKey("messages.id"), primary_key=True),
-)
-
-
-class Message(Base):
-    __tablename__ = "messages"
-
-    id = Column(types.Uuid, primary_key=True)  # type: ignore[attr-defined]
-    chat_id = Column(ForeignKey("chats.id"))
-    content = Column(types.String)
-    role = Column(types.Enum(MessageRole))
-    sources = relationship(
-        "Source",
-        secondary=source_message_association_table,
-        back_populates="messages",
-    )
-    timestamp = Column(types.DateTime)
-
-
 class Chat(Base):
     __tablename__ = "chats"
 
@@ -110,9 +87,17 @@ class Chat(Base):
     assistant = Column(types.String)
     params = Column(Json)
     messages = relationship(
-        "Message", cascade="all, delete", order_by=[Message.timestamp, Message.role]
+        "Message", cascade="all, delete", order_by="Message.timestamp"
     )
     prepared = Column(types.Boolean)
+
+
+source_message_association_table = Table(
+    "source_message_association_table",
+    Base.metadata,
+    Column("source_id", ForeignKey("sources.id"), primary_key=True),
+    Column("message_id", ForeignKey("messages.id"), primary_key=True),
+)
 
 
 class Source(Base):
@@ -135,3 +120,18 @@ class Source(Base):
         secondary=source_message_association_table,
         back_populates="sources",
     )
+
+
+class Message(Base):
+    __tablename__ = "messages"
+
+    id = Column(types.Uuid, primary_key=True)  # type: ignore[attr-defined]
+    chat_id = Column(ForeignKey("chats.id"))
+    content = Column(types.String)
+    role = Column(types.Enum(MessageRole))
+    sources = relationship(
+        "Source",
+        secondary=source_message_association_table,
+        back_populates="messages",
+    )
+    timestamp = Column(types.DateTime)

--- a/ragna/deploy/_api/orm.py
+++ b/ragna/deploy/_api/orm.py
@@ -72,6 +72,29 @@ class Document(Base):
     )
 
 
+source_message_association_table = Table(
+    "source_message_association_table",
+    Base.metadata,
+    Column("source_id", ForeignKey("sources.id"), primary_key=True),
+    Column("message_id", ForeignKey("messages.id"), primary_key=True),
+)
+
+
+class Message(Base):
+    __tablename__ = "messages"
+
+    id = Column(types.Uuid, primary_key=True)  # type: ignore[attr-defined]
+    chat_id = Column(ForeignKey("chats.id"))
+    content = Column(types.String)
+    role = Column(types.Enum(MessageRole))
+    sources = relationship(
+        "Source",
+        secondary=source_message_association_table,
+        back_populates="messages",
+    )
+    timestamp = Column(types.DateTime)
+
+
 class Chat(Base):
     __tablename__ = "chats"
 
@@ -87,17 +110,9 @@ class Chat(Base):
     assistant = Column(types.String)
     params = Column(Json)
     messages = relationship(
-        "Message", cascade="all, delete", order_by="Message.timestamp"
+        "Message", cascade="all, delete", order_by=[Message.timestamp, Message.role]
     )
     prepared = Column(types.Boolean)
-
-
-source_message_association_table = Table(
-    "source_message_association_table",
-    Base.metadata,
-    Column("source_id", ForeignKey("sources.id"), primary_key=True),
-    Column("message_id", ForeignKey("messages.id"), primary_key=True),
-)
 
 
 class Source(Base):
@@ -120,18 +135,3 @@ class Source(Base):
         secondary=source_message_association_table,
         back_populates="sources",
     )
-
-
-class Message(Base):
-    __tablename__ = "messages"
-
-    id = Column(types.Uuid, primary_key=True)  # type: ignore[attr-defined]
-    chat_id = Column(ForeignKey("chats.id"))
-    content = Column(types.String)
-    role = Column(types.Enum(MessageRole))
-    sources = relationship(
-        "Source",
-        secondary=source_message_association_table,
-        back_populates="messages",
-    )
-    timestamp = Column(types.DateTime)

--- a/ragna/deploy/_api/orm.py
+++ b/ragna/deploy/_api/orm.py
@@ -86,7 +86,9 @@ class Chat(Base):
     source_storage = Column(types.String)
     assistant = Column(types.String)
     params = Column(Json)
-    messages = relationship("Message", cascade="all, delete")
+    messages = relationship(
+        "Message", cascade="all, delete", order_by="Message.timestamp"
+    )
     prepared = Column(types.Boolean)
 
 

--- a/ragna/deploy/_api/schemas.py
+++ b/ragna/deploy/_api/schemas.py
@@ -56,9 +56,7 @@ class Message(BaseModel):
     content: str
     role: ragna.core.MessageRole
     sources: list[Source] = Field(default_factory=list)
-    timestamp: datetime.datetime = Field(
-        default_factory=lambda: datetime.datetime.utcnow()
-    )
+    timestamp: datetime.datetime = Field(default_factory=datetime.datetime.utcnow)
 
     @classmethod
     def from_core(cls, message: ragna.core.Message) -> Message:

--- a/tests/deploy/api/test_e2e.py
+++ b/tests/deploy/api/test_e2e.py
@@ -119,6 +119,8 @@ def test_e2e(tmp_local_root, multiple_answer_chunks, stream_answer):
         }
 
         chat = client.get(f"/chats/{chat['id']}").raise_for_status().json()
+        for message in chat["messages"]:
+            print(f"{message['role']=}, {message['timestamp']=}")
         assert len(chat["messages"]) == 3
         assert (
             chat["messages"][-2]["role"] == "user"

--- a/tests/deploy/api/test_e2e.py
+++ b/tests/deploy/api/test_e2e.py
@@ -121,14 +121,12 @@ def test_e2e(tmp_local_root, multiple_answer_chunks, stream_answer):
         }
 
         chat = client.get(f"/chats/{chat['id']}").raise_for_status().json()
-        for message in chat["messages"]:
-            print(f"{message['role']=}, {message['timestamp']=}")
         assert len(chat["messages"]) == 3
         assert (
             chat["messages"][-2]["role"] == "user"
             and chat["messages"][-2]["sources"] == []
             and chat["messages"][-2]["content"] == prompt
-        ), [m["timestamp"] for m in chat["messages"]]
+        )
         assert chat["messages"][-1] == message
 
         client.delete(f"/chats/{chat['id']}").raise_for_status()

--- a/tests/deploy/api/test_e2e.py
+++ b/tests/deploy/api/test_e2e.py
@@ -124,7 +124,7 @@ def test_e2e(tmp_local_root, multiple_answer_chunks, stream_answer):
             chat["messages"][-2]["role"] == "user"
             and chat["messages"][-2]["sources"] == []
             and chat["messages"][-2]["content"] == prompt
-        )
+        ), [m["timestamp"] for m in chat["messages"]]
         assert chat["messages"][-1] == message
 
         client.delete(f"/chats/{chat['id']}").raise_for_status()

--- a/tests/deploy/api/test_e2e.py
+++ b/tests/deploy/api/test_e2e.py
@@ -1,4 +1,5 @@
 import json
+import time
 
 import pytest
 from fastapi.testclient import TestClient
@@ -12,6 +13,7 @@ from .utils import authenticate
 
 class TestAssistant(RagnaDemoAssistant):
     def answer(self, prompt, sources, *, multiple_answer_chunks: bool):
+        time.sleep(1e-3)
         content = next(super().answer(prompt, sources))
 
         if multiple_answer_chunks:

--- a/tests/deploy/api/test_e2e.py
+++ b/tests/deploy/api/test_e2e.py
@@ -129,16 +129,3 @@ def test_e2e(tmp_local_root, multiple_answer_chunks, stream_answer):
 
         client.delete(f"/chats/{chat['id']}").raise_for_status()
         assert client.get("/chats").raise_for_status().json() == []
-
-
-def test_default_factory():
-    import time
-
-    from ragna.core import MessageRole
-    from ragna.deploy._api import schemas
-
-    msg1 = schemas.Message(content="content1", role=MessageRole.USER)
-    time.sleep(3)
-    msg2 = schemas.Message(content="content2", role=MessageRole.ASSISTANT)
-    assert msg1.id != msg2.id
-    assert msg1.timestamp != msg2.timestamp

--- a/tests/deploy/api/test_e2e.py
+++ b/tests/deploy/api/test_e2e.py
@@ -129,3 +129,16 @@ def test_e2e(tmp_local_root, multiple_answer_chunks, stream_answer):
 
         client.delete(f"/chats/{chat['id']}").raise_for_status()
         assert client.get("/chats").raise_for_status().json() == []
+
+
+def test_default_factory():
+    import time
+
+    from ragna.core import MessageRole
+    from ragna.deploy._api import schemas
+
+    msg1 = schemas.Message(content="content1", role=MessageRole.USER)
+    time.sleep(3)
+    msg2 = schemas.Message(content="content2", role=MessageRole.ASSISTANT)
+    assert msg1.id != msg2.id
+    assert msg1.timestamp != msg2.timestamp

--- a/tests/deploy/api/test_e2e.py
+++ b/tests/deploy/api/test_e2e.py
@@ -13,6 +13,9 @@ from .utils import authenticate
 
 class TestAssistant(RagnaDemoAssistant):
     def answer(self, prompt, sources, *, multiple_answer_chunks: bool):
+        # Simulate a "real" assistant through a small delay. See
+        # https://github.com/Quansight/ragna/pull/401#issuecomment-2095851440
+        # for why this is needed.
         time.sleep(1e-3)
         content = next(super().answer(prompt, sources))
 


### PR DESCRIPTION
This is an attempt at solving issue #399 

Using `lazy="joined"` on all the relationships was one way of doing it. I think we should use the alternative `joinedload` for more flexibility. It's kind of the same but we have the control over when we want to use it. 

I'd like your feedback on the performances in the various contexts you're using it. I've tested it locally, adding `echo=True` to `create_engine`. I could see that before this fix, there was a query to retrieve all chats, and then queries to get documents, messages and sources for each chat. After the fix, I see only one query to them all.

Unit tests are passing locally, except 2 but they seem related to my local setup