### PR TITLE
update ignored deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,10 +103,8 @@ testpaths = [
 filterwarnings = [
     "error",
     "ignore::ResourceWarning",
-    # httpx 0.27.0 deprecated some functionality that the test client of starlette /
-    # FastApi use. This should be resolved by the next release of these libraries.
-    # See https://github.com/encode/starlette/issues/2524
-    "ignore:The 'app' shortcut is now deprecated:DeprecationWarning",
+    # https://github.com/lancedb/lancedb/issues/1296
+    "ignore:Function 'semver.parse_version_info' is deprecated:DeprecationWarning"
 ]
 xfail_strict = true
 


### PR DESCRIPTION
- Removes the ignore for a deprecation warning that came from `starlette`, but is fixed now.
- Adds a new ignore for deprecation warnings that were introduced by the latest release of `lancedb`. See lancedb/lancedb#1296