### PR TITLE
Load message history to core chat from schema chat

### DIFF
--- a/ragna/deploy/_api/core.py
+++ b/ragna/deploy/_api/core.py
@@ -234,7 +234,7 @@ def app(*, config: Config, ignore_unavailable_components: bool) -> FastAPI:
             **chat.metadata.params,
         )
         core_chat._messages = [
-            schemas.Message.to_core(message) for message in chat.messages
+            message.to_core() for message in chat.messages
         ]
         core_chat._prepared = chat.prepared
 

--- a/ragna/deploy/_api/core.py
+++ b/ragna/deploy/_api/core.py
@@ -233,7 +233,9 @@ def app(*, config: Config, ignore_unavailable_components: bool) -> FastAPI:
             chat_name=chat.metadata.name,
             **chat.metadata.params,
         )
-        core_chat._messages = [message.to_core() for message in chat.messages]
+        core_chat._messages = [
+            message.to_core() for message in chat.messages
+        ]
         core_chat._prepared = chat.prepared
 
         return core_chat

--- a/ragna/deploy/_api/core.py
+++ b/ragna/deploy/_api/core.py
@@ -233,11 +233,9 @@ def app(*, config: Config, ignore_unavailable_components: bool) -> FastAPI:
             chat_name=chat.metadata.name,
             **chat.metadata.params,
         )
-        # FIXME: We need to reconstruct the previous messages here. Right now this is
-        #  not needed, because the chat itself never accesses past messages. However,
-        #  if we implement a chat history feature, i.e. passing past messages to
-        #  the assistant, this becomes crucial.
-        core_chat._messages = []
+        core_chat._messages = [
+            schemas.Message.to_core(message) for message in chat.messages
+        ]
         core_chat._prepared = chat.prepared
 
         return core_chat

--- a/ragna/deploy/_api/core.py
+++ b/ragna/deploy/_api/core.py
@@ -233,9 +233,7 @@ def app(*, config: Config, ignore_unavailable_components: bool) -> FastAPI:
             chat_name=chat.metadata.name,
             **chat.metadata.params,
         )
-        core_chat._messages = [
-            message.to_core() for message in chat.messages
-        ]
+        core_chat._messages = [message.to_core() for message in chat.messages]
         core_chat._prepared = chat.prepared
 
         return core_chat

--- a/ragna/deploy/_api/schemas.py
+++ b/ragna/deploy/_api/schemas.py
@@ -26,6 +26,13 @@ class Document(BaseModel):
             name=document.name,
         )
 
+    @classmethod
+    def to_core(cls, document: Document) -> ragna.core.Document:
+        return ragna.core.Document(
+            id=document.id,
+            name=document.name,
+        )
+
 
 class DocumentUpload(BaseModel):
     parameters: ragna.core.DocumentUploadParameters
@@ -45,6 +52,16 @@ class Source(BaseModel):
         return cls(
             id=source.id,
             document=Document.from_core(source.document),
+            location=source.location,
+            content=source.content,
+            num_tokens=source.num_tokens,
+        )
+
+    @classmethod
+    def to_core(cls, source: Source) -> ragna.core.Source:
+        return ragna.core.Source(
+            id=source.id,
+            document=Document.to_core(source.document),
             location=source.location,
             content=source.content,
             num_tokens=source.num_tokens,
@@ -70,7 +87,7 @@ class Message(BaseModel):
         return ragna.core.Message(
             content=self.content,
             role=self.role,
-            sources=[],
+            sources=[source.to_core() for source in self.sources],
         )
 
 

--- a/ragna/deploy/_api/schemas.py
+++ b/ragna/deploy/_api/schemas.py
@@ -26,13 +26,6 @@ class Document(BaseModel):
             name=document.name,
         )
 
-    @classmethod
-    def to_core(cls, document: Document) -> ragna.core.Document:
-        return ragna.core.Document(
-            id=document.id,
-            name=document.name,
-        )
-
 
 class DocumentUpload(BaseModel):
     parameters: ragna.core.DocumentUploadParameters
@@ -52,16 +45,6 @@ class Source(BaseModel):
         return cls(
             id=source.id,
             document=Document.from_core(source.document),
-            location=source.location,
-            content=source.content,
-            num_tokens=source.num_tokens,
-        )
-
-    @classmethod
-    def to_core(cls, source: Source) -> ragna.core.Source:
-        return ragna.core.Source(
-            id=source.id,
-            document=Document.to_core(source.document),
             location=source.location,
             content=source.content,
             num_tokens=source.num_tokens,
@@ -87,7 +70,7 @@ class Message(BaseModel):
         return ragna.core.Message(
             content=self.content,
             role=self.role,
-            sources=[source.to_core() for source in self.sources],
+            sources=[],
         )
 
 

--- a/ragna/deploy/_api/schemas.py
+++ b/ragna/deploy/_api/schemas.py
@@ -26,11 +26,14 @@ class Document(BaseModel):
             name=document.name,
         )
 
-    @classmethod
-    def to_core(cls, document: Document) -> ragna.core.Document:
-        return ragna.core.Document(
-            id=document.id,
-            name=document.name,
+    def to_core(self) -> ragna.core.Document:
+        return ragna.core.LocalDocument(
+            id=self.id,
+            name=self.name,
+            # TEMP: setting an empty metadata dict for now.
+            # Will be resolved as part of the "managed ragna" work:
+            # https://github.com/Quansight/ragna/issues/256
+            metadata={},
         )
 
 
@@ -57,14 +60,13 @@ class Source(BaseModel):
             num_tokens=source.num_tokens,
         )
 
-    @classmethod
-    def to_core(cls, source: Source) -> ragna.core.Source:
+    def to_core(self) -> ragna.core.Source:
         return ragna.core.Source(
-            id=source.id,
-            document=Document.to_core(source.document),
-            location=source.location,
-            content=source.content,
-            num_tokens=source.num_tokens,
+            id=self.id,
+            document=self.document.to_core(),
+            location=self.location,
+            content=self.content,
+            num_tokens=self.num_tokens,
         )
 
 

--- a/ragna/deploy/_api/schemas.py
+++ b/ragna/deploy/_api/schemas.py
@@ -83,12 +83,11 @@ class Message(BaseModel):
             sources=[Source.from_core(source) for source in message.sources],
         )
 
-    @classmethod
-    def to_core(cls, message: Message) -> ragna.core.Message:
+    def to_core(self) -> ragna.core.Message:
         return ragna.core.Message(
-            content=message.content,
-            role=message.role,
-            sources=[Source.to_core(source) for source in message.sources],
+            content=self.content,
+            role=self.role,
+            sources=[source.to_core() for source in self.sources],
         )
 
 

--- a/ragna/deploy/_api/schemas.py
+++ b/ragna/deploy/_api/schemas.py
@@ -26,6 +26,13 @@ class Document(BaseModel):
             name=document.name,
         )
 
+    @classmethod
+    def to_core(cls, document: Document) -> ragna.core.Document:
+        return ragna.core.Document(
+            id=document.id,
+            name=document.name,
+        )
+
 
 class DocumentUpload(BaseModel):
     parameters: ragna.core.DocumentUploadParameters
@@ -50,6 +57,16 @@ class Source(BaseModel):
             num_tokens=source.num_tokens,
         )
 
+    @classmethod
+    def to_core(cls, source: Source) -> ragna.core.Source:
+        return ragna.core.Source(
+            id=source.id,
+            document=Document.to_core(source.document),
+            location=source.location,
+            content=source.content,
+            num_tokens=source.num_tokens,
+        )
+
 
 class Message(BaseModel):
     id: uuid.UUID = Field(default_factory=uuid.uuid4)
@@ -64,6 +81,14 @@ class Message(BaseModel):
             content=message.content,
             role=message.role,
             sources=[Source.from_core(source) for source in message.sources],
+        )
+
+    @classmethod
+    def to_core(cls, message: Message) -> ragna.core.Message:
+        return ragna.core.Message(
+            content=message.content,
+            role=message.role,
+            sources=[Source.to_core(source) for source in message.sources],
         )
 
 


### PR DESCRIPTION
Basic prereq for passing chat history down the pipeline. History is already present in the `schema.Chat` object loaded from the database, so we just need to make sure it also gets loaded into the `ragna.core.Chat` object inside [schema_to_core_chat](https://github.com/Quansight/ragna/blob/647a61e3103cb2e54b7c5bc2da5df1e2906b059b/ragna/deploy/_api/core.py#L213).

https://github.com/Quansight/ragna/blob/647a61e3103cb2e54b7c5bc2da5df1e2906b059b/ragna/deploy/_api/core.py#L290-L297