### PR TITLE
WIP draft of generate() outside of chat.answer()

### DIFF
--- a/environment-dev-exl.yml
+++ b/environment-dev-exl.yml
@@ -1,0 +1,43 @@
+name: ragna-dev-exl
+channels:
+  - pytorch
+  - nvidia
+  - conda-forge
+  - defaults
+dependencies:
+  - python =3.11
+  - pip
+  - git-lfs
+  - jupyterlab>=3
+  - pandas
+  - numpy
+  - panel
+  - tokenizers
+  - pytorch=2.3.1
+  - pytorch-cuda=12.1
+  - cuda-nvcc
+  - rich
+  - pip:
+      - python-dotenv
+      - pytest >=6
+      - pytest-mock
+      - pytest-asyncio
+      - pytest-playwright
+      - mypy ==1.10.0
+      - pre-commit
+      - types-aiofiles
+      - sqlalchemy-stubs
+      - setuptools-scm
+      - pip-tools
+      # documentation
+      - mkdocs
+      - mkdocs-material
+      - mkdocstrings[python]
+      - mkdocs-gen-files
+      - material-plausible-plugin
+      - mkdocs-gallery >=0.10
+      - mdx_truly_sane_lists
+      # exl2
+      - ninja
+      - packaging
+      - exllamav2@https://github.com/turboderp/exllamav2/releases/download/v0.1.5/exllamav2-0.1.5+cu121.torch2.3.1-cp311-cp311-linux_x86_64.whl

--- a/ragna/assistants/__init__.py
+++ b/ragna/assistants/__init__.py
@@ -18,8 +18,10 @@ __all__ = [
     "Jurassic2Ultra",
     "LlamafileAssistant",
     "RagnaDemoAssistant",
+    "Exl2Assistant",
 ]
 
+from ._exl2 import Exl2Assistant
 from ._ai21labs import Jurassic2Ultra
 from ._anthropic import ClaudeHaiku, ClaudeOpus, ClaudeSonnet
 from ._cohere import Command, CommandLight

--- a/ragna/assistants/_exl2.py
+++ b/ragna/assistants/_exl2.py
@@ -1,0 +1,123 @@
+import re
+import textwrap
+from typing import Iterator, Union, cast
+
+from ragna.core import Assistant, Source
+from pathlib import Path
+
+from exllamav2 import(
+    ExLlamaV2,
+    ExLlamaV2Config,
+    ExLlamaV2Cache,
+    ExLlamaV2Tokenizer,
+    ExLlamaV2Cache_Q4,
+)
+
+from exllamav2.generator import (
+    ExLlamaV2BaseGenerator,
+    ExLlamaV2Sampler,
+    ExLlamaV2DynamicGenerator,
+    ExLlamaV2DynamicJob,
+    ExLlamaV2DynamicGeneratorAsync,
+    ExLlamaV2DynamicJobAsync,
+)
+
+import time
+
+class Exl2Assistant(Assistant):
+    """Exl2Assistant - example to instantiate and run inference in process
+    """
+
+    @classmethod
+    def display_name(cls) -> str:
+        return "Ragna/Exl2Assistant"
+
+    # TODO; known needs: - pytorch, pytorch-cuda, [cuda-nvcc, rich, ninja, packaging, flash-attn] for paged attention batching, exllamav2
+    # @classmethod
+    # def requirements(cls, protocol: HttpStreamingProtocol) -> list[Requirement]:
+    #     streaming_requirements: dict[HttpStreamingProtocol, list[Requirement]] = {
+    #         HttpStreamingProtocol.SSE: [PackageRequirement("httpx_sse")],
+    #     }
+    # return streaming_requirements.get(protocol, [])
+
+    def __init__(
+        self,
+    ) -> None:
+        self._stream = False
+        self._paged = False
+        self._max_seq_length = 8192
+        self._max_new_tokens = 512
+        self._model_directory = ""
+        self._load()
+        
+    def _load(self):
+        self._config = ExLlamaV2Config(self._model_directory)
+        self._config.prepare()
+        self._config.max_seq_len = self._max_seq_length
+        self._model = ExLlamaV2(self._config)
+        self._cache = ExLlamaV2Cache_Q4(self._model, lazy = True, max_seq_len=self._config.max_seq_len)
+        self._model.load_autosplit(self._cache)
+        self._tokenizer = ExLlamaV2Tokenizer(self._config)
+        self.settings = ExLlamaV2Sampler.Settings()
+        self.settings.temperature = 0.35
+        self.settings.top_k = 50
+        self.settings.top_p = 0.8
+        self.settings.token_repetition_penalty = 1.05
+
+    def _render_prompt(self, prompt: str) -> str:
+        system_prompt="You are an unbiased, helpful assistant."
+        texts = [f"<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\n{system_prompt}<|eot_id|>\n"]
+        texts.append(f'<|start_header_id|>user<|end_header_id|>\n\n{prompt}<|eot_id|>\n<|start_header_id|>assistant<|end_header_id|>')
+        return ''.join(texts)
+
+
+    async def generate(self, prompt: str) -> str:
+        full_prompt = self._render_prompt(prompt)
+
+        self._generator = ExLlamaV2DynamicGenerator(
+            model = self._model,
+            cache = self._cache,
+            tokenizer = self._tokenizer,
+            gen_settings = self.settings,
+            paged = self._paged,
+        )
+        outputs = self._generator.generate(
+            prompt = full_prompt,
+            max_new_tokens = self._max_new_tokens,
+            stop_conditions = ["</s>","<|eot_id|>", self._tokenizer.eos_token_id],
+            completion_only = True,
+        )
+        yield outputs
+            
+    
+    async def answer(self, prompt: str, sources: list[Source]) -> Iterator[str]:
+        full_prompt = self._render_prompt(prompt)
+        input_ids = self._tokenizer.encode(full_prompt)
+        #examples at https://github.com/turboderp/exllamav2/blob/master/examples/inference_stream.py
+        #and         https://github.com/turboderp/exllamav2/blob/master/examples/inference_async.py
+        if self._stream:
+            self._generator = ExLlamaV2DynamicGeneratorAsync(
+                model = self._model,
+                cache = self._cache,
+                tokenizer = self._tokenizer,
+                paged = self._paged,
+                gen_settings = self.settings,
+            )
+            job = ExLlamaV2DynamicJobAsync(
+                generator = self._generator,
+                input_ids = input_ids,
+                max_new_tokens = self._max_new_tokens,
+                token_healing = True,
+                stop_conditions = ["</s>","<|eot_id|>", self._tokenizer.eos_token_id],
+                completion_only = True,
+            )
+            async for result in job:
+                text_chunk = result.get("text", "")
+                if not result["eos"]:
+                    yield cast(str, text_chunk)
+            await self._generator.close()
+        else:
+            yield [i async for i in self.generate(prompt)][0]
+
+
+

--- a/ragna/core/_components.py
+++ b/ragna/core/_components.py
@@ -210,10 +210,24 @@ class Message:
 class Assistant(Component, abc.ABC):
     """Abstract base class for assistants used in [ragna.core.Chat][]"""
 
-    __ragna_protocol_methods__ = ["answer"]
+    __ragna_protocol_methods__ = ["answer","generate"]
 
     @abc.abstractmethod
     def answer(self, prompt: str, sources: list[Source]) -> Iterator[str]:
+        """Answer a prompt given some sources.
+
+        Args:
+            prompt: Prompt to be answered.
+            sources: Sources to use when answering answer the prompt.
+
+        Returns:
+            Answer.
+        """
+        ...
+
+    @abc.abstractmethod
+    def generate(self, prompt: str) -> str:
+        #TODO
         """Answer a prompt given some sources.
 
         Args:

--- a/ragna/core/_rag.py
+++ b/ragna/core/_rag.py
@@ -232,6 +232,26 @@ class Chat:
 
         return answer
 
+    async def generate(self, *, prompt: str) -> str:
+        """Run Inference on assistant endpoint
+
+        Returns:
+            Answer.
+
+        Raises:
+            ragna.core.RagnaException: If chat is not
+                [`prepare`][ragna.core.Chat.prepare]d.
+        """
+        if not self._prepared:
+            raise RagnaException(
+                "Chat is not prepared",
+                chat=self,
+                http_status_code=400,
+                detail=RagnaException.EVENT,
+            )
+
+        return self._run_gen(self.assistant.generate, prompt)
+
     def _parse_documents(self, documents: Iterable[Any]) -> list[Document]:
         documents_ = []
         for document in documents:


### PR DESCRIPTION
Takes format from chat.answer and duplicates, without sources, as chat.generate which then gets implemented in Assistant as well. Got a bit turned around with the async aspect in the stream = False case, room for cleanup. The exl2 assistant is currently instantiating a number of vars it likely should be taking from Chat instead (e.g. stream:bool)