### PR TITLE
refactor protocol model extraction to only check extra parameters

### DIFF
--- a/ragna/core/_rag.py
+++ b/ragna/core/_rag.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import contextlib
 import datetime
 import inspect
+import itertools
 import uuid
+from collections import defaultdict
 from typing import (
     Any,
     AsyncIterator,
@@ -251,6 +254,15 @@ class Chat:
     def _unpack_chat_params(
         self, params: dict[str, Any]
     ) -> dict[Callable, dict[str, Any]]:
+        # This method does two things:
+        # 1. Validate the **params against the signatures of the protocol methods of the
+        #    used components. This makes sure that
+        #    - No parameter is passed that isn't used by at least one component
+        #    - No parameter is missing that is needed by at least one component
+        #    - No parameter is passed in the wrong type
+        # 2. Prepare the distribution of the parameters to the protocol method that
+        #    requested them. The actual distribution happens in self._run and
+        #    self._run_gen, but is only a dictionary lookup by then.
         component_models = {
             getattr(component, name): model
             for component in [self.source_storage, self.assistant]
@@ -258,19 +270,96 @@ class Chat:
         }
 
         ChatModel = merge_models(
-            str(self.params["chat_id"]),
+            f"{self.__module__}.{type(self).__name__}-{self.params['chat_id']}",
             SpecialChatParams,
             *component_models.values(),
             config=pydantic.ConfigDict(extra="forbid"),
         )
 
-        chat_params = ChatModel.model_validate(params, strict=True).model_dump(
-            exclude_none=True
-        )
+        with self._format_validation_error(ChatModel):
+            chat_model = ChatModel.model_validate(params, strict=True)
+
+        chat_params = chat_model.model_dump(exclude_none=True)
         return {
             fn: model(**chat_params).model_dump()
             for fn, model in component_models.items()
         }
+
+    @contextlib.contextmanager
+    def _format_validation_error(self, foo):
+        try:
+            yield
+        except pydantic.ValidationError as validation_error:
+            errors = defaultdict(list)
+            for error in validation_error.errors():
+                errors[error["type"]].append(error)
+
+            parts = [
+                f"Validating the Chat parameters resulted in {validation_error.error_count()} errors:",
+                "",
+            ]
+
+            def format_error(
+                error: dict[str, Any], *, annotation: bool = False, value: bool = False
+            ) -> str:
+                param = error["loc"][0]
+
+                formatted_error = f"- {param}"
+                if annotation:
+                    annotation_ = foo.model_fields[param].annotation.__name__
+                    formatted_error += f": {annotation_}"
+
+                if value:
+                    value_ = error["input"]
+                    formatted_error += (
+                        f" = {value_!r}" if annotation else f"={value_!r}"
+                    )
+
+                return formatted_error
+
+            if "extra_forbidden" in errors:
+                parts.extend(
+                    [
+                        "The following parameters are unknown:",
+                        "",
+                        *[
+                            format_error(error, value=True)
+                            for error in errors["extra_forbidden"]
+                        ],
+                        "",
+                    ]
+                )
+
+            if "missing" in errors:
+                parts.extend(
+                    [
+                        "The following parameters are missing:",
+                        "",
+                        *[
+                            format_error(error, annotation=True)
+                            for error in errors["missing"]
+                        ],
+                        "",
+                    ]
+                )
+
+            type_errors = ["string_type", "int_type", "float_type", "bool_type"]
+            if any(type_error in errors for type_error in type_errors):
+                parts.extend(
+                    [
+                        "The following parameters have the wrong type:",
+                        "",
+                        *[
+                            format_error(error, annotation=True, value=True)
+                            for error in itertools.chain.from_iterable(
+                                errors[type_error] for type_error in type_errors
+                            )
+                        ],
+                        "",
+                    ]
+                )
+
+            raise RagnaException("\n".join(parts))
 
     async def _run(
         self, fn: Union[Callable[..., T], Callable[..., Awaitable[T]]], *args: Any

--- a/tests/core/test_rag.py
+++ b/tests/core/test_rag.py
@@ -1,8 +1,7 @@
-import pydantic
 import pytest
 
 from ragna import Rag, assistants, source_storages
-from ragna.core import LocalDocument
+from ragna.core import Assistant, LocalDocument, RagnaException
 
 
 @pytest.fixture()
@@ -14,19 +13,83 @@ def demo_document(tmp_path, request):
 
 
 class TestChat:
-    def chat(self, documents, **params):
+    def chat(
+        self,
+        documents,
+        source_storage=source_storages.RagnaDemoSourceStorage,
+        assistant=assistants.RagnaDemoAssistant,
+        **params,
+    ):
         return Rag().chat(
             documents=documents,
-            source_storage=source_storages.RagnaDemoSourceStorage,
-            assistant=assistants.RagnaDemoAssistant,
+            source_storage=source_storage,
+            assistant=assistant,
             **params,
         )
 
-    def test_extra_params(self, demo_document):
-        with pytest.raises(pydantic.ValidationError, match="not_supported_parameter"):
+    def test_params_validation_unknown(self, demo_document):
+        params = {
+            "bool_param": False,
+            "int_param": 1,
+            "float_param": 0.5,
+            "string_param": "arbitrary_value",
+        }
+        with pytest.raises(RagnaException, match="unknown") as exc_info:
+            self.chat(documents=[demo_document], **params)
+
+        msg = str(exc_info.value)
+        for param, value in params.items():
+            assert f"{param}={value!r}" in msg
+
+    def test_params_validation_missing(self, demo_document):
+        class ValidationAssistant(Assistant):
+            def answer(
+                self,
+                prompt,
+                sources,
+                bool_param: bool,
+                int_param: int,
+                float_param: float,
+                string_param: str,
+            ):
+                pass
+
+        with pytest.raises(RagnaException, match="missing") as exc_info:
+            self.chat(documents=[demo_document], assistant=ValidationAssistant)
+
+        msg = str(exc_info.value)
+        for param, annotation in ValidationAssistant.answer.__annotations__.items():
+            assert f"{param}: {annotation.__name__}" in msg
+
+    def test_params_validation_wrong_type(self, demo_document):
+        class ValidationAssistant(Assistant):
+            def answer(
+                self,
+                prompt,
+                sources,
+                bool_param: bool,
+                int_param: int,
+                float_param: float,
+                string_param: str,
+            ):
+                pass
+
+        params = {
+            "bool_param": 1,
+            "int_param": 0.5,
+            "float_param": "arbitrary_value",
+            "string_param": False,
+        }
+
+        with pytest.raises(RagnaException, match="wrong type") as exc_info:
             self.chat(
-                documents=[demo_document], not_supported_parameter="arbitrary_value"
+                documents=[demo_document], assistant=ValidationAssistant, **params
             )
+
+        msg = str(exc_info.value)
+        for param, value in params.items():
+            annotation = ValidationAssistant.answer.__annotations__[param]
+            assert f"{param}: {annotation.__name__} = {value!r}" in msg
 
     def test_document_path(self, demo_document):
         chat = self.chat(documents=[demo_document.path])


### PR DESCRIPTION
This PR changes two things:

1. The previous implementation for the extraction of the protocol models relied on the fact that the concrete subclasses use the exact same names for the protocol parameters, i.e. the parameters defined by the protocol base class. This is rather restricting, undocumented, and has bitten us before (https://github.com/Quansight/ragna/pull/369#issuecomment-2019756910). With this PR we identify the extra parameters by skipping the first `n` parameters in the concrete signature, where `n` is the number of protocol parameters.
2. Previously we just passed through the Pydantic validation error in case of a failure. While this contains all the information you need if you know the internals of Ragna, it is hard to parse for users. Especially, because they don't have any touching point with Pydantic and we are thus "leaking internals". This PR adds logic to parse the raw errors and format them in a user friendly way.

For example:

```python
from ragna import Rag, source_storages
from ragna.core import Assistant


class ValidationAssistant(Assistant):
    def answer(
        self,
        prompt,
        sources,
        bool_param: bool,
        int_param: int,
        float_param: float,
        string_param: str,
    ):
        pass


async def main():
    async with Rag().chat(
        documents=["README.md"],
        source_storage=source_storages.RagnaDemoSourceStorage,
        assistant=ValidationAssistant,
        unknown=True,
        bool_param=False,
        float_param="string_value",
        string_param=42,
    ):
        pass


import asyncio

asyncio.run(main())
```

#### `main`

```
pydantic_core._pydantic_core.ValidationError: 4 validation errors for ec32e2f5-ad2d-4d08-8987-609f8e47a6d0
int_param
  Field required [type=missing, input_value={'user': 'philip', 'chat_...ue', 'string_param': 42}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.7/v/missing
float_param
  Input should be a valid number [type=float_type, input_value='string_value', input_type=str]
    For further information visit https://errors.pydantic.dev/2.7/v/float_type
string_param
  Input should be a valid string [type=string_type, input_value=42, input_type=int]
    For further information visit https://errors.pydantic.dev/2.7/v/string_type
unknown
  Extra inputs are not permitted [type=extra_forbidden, input_value=True, input_type=bool]
    For further information visit https://errors.pydantic.dev/2.7/v/extra_forbidden
```

#### PR

```
ragna.core.RagnaException: Validating the Chat parameters resulted in 4 errors:

The following parameters are unknown:

- unknown=True

The following parameters are missing:

- int_param: int

The following parameters have the wrong type:

- string_param: str = 42
- float_param: float = 'string_value'
```