### PR TITLE
support chat history

### DIFF
--- a/docs/examples/gallery_streaming.py
+++ b/docs/examples/gallery_streaming.py
@@ -44,8 +44,8 @@ from ragna import assistants
 
 
 class DemoStreamingAssistant(assistants.RagnaDemoAssistant):
-    def answer(self, prompt, sources):
-        content = next(super().answer(prompt, sources))
+    def answer(self, messages):
+        content = next(super().answer(messages))
         for chunk in content.split(" "):
             yield f"{chunk} "
 

--- a/docs/tutorials/gallery_custom_components.py
+++ b/docs/tutorials/gallery_custom_components.py
@@ -30,7 +30,7 @@ to incorporate custom components. This tutorial covers how to do that.
 
 import uuid
 
-from ragna.core import Document, Source, SourceStorage
+from ragna.core import Document, Source, SourceStorage, Message
 
 
 class TutorialSourceStorage(SourceStorage):
@@ -61,7 +61,7 @@ class TutorialSourceStorage(SourceStorage):
 # %%
 # ### Assistant
 #
-# [ragna.core.Assistant][]s are objects that take a user prompt and relevant
+# [ragna.core.Assistant][]s are objects that take a list of messages containing one or more user prompts and relevant
 # [ragna.core.Source][]s and generate a response form that. Usually, assistants are
 # LLMs.
 #
@@ -82,8 +82,9 @@ from ragna.core import Assistant, Source
 
 
 class TutorialAssistant(Assistant):
-    def answer(self, prompt: str, sources: list[Source]) -> Iterator[str]:
+    def answer(self, messages: list[Message]) -> Iterator[str]:
         print(f"Running {type(self).__name__}().answer()")
+        prompt, sources = (message := messages[-1]).content, message.sources
         yield (
             f"To answer the user prompt '{prompt}', "
             f"I was given {len(sources)} source(s)."
@@ -254,8 +255,7 @@ rest_api.stop()
 class ElaborateTutorialAssistant(Assistant):
     def answer(
         self,
-        prompt: str,
-        sources: list[Source],
+        messages: list[Message],
         *,
         my_required_parameter: int,
         my_optional_parameter: str = "foo",
@@ -393,9 +393,7 @@ from typing import AsyncIterator
 
 
 class AsyncAssistant(Assistant):
-    async def answer(
-        self, prompt: str, sources: list[Source]
-    ) -> AsyncIterator[str]:
+    async def answer(self, messages: list[Message]) -> AsyncIterator[str]:
         print(f"Running {type(self).__name__}().answer()")
         start = time.perf_counter()
         await asyncio.sleep(0.3)

--- a/docs/tutorials/gallery_custom_components.py
+++ b/docs/tutorials/gallery_custom_components.py
@@ -61,9 +61,9 @@ class TutorialSourceStorage(SourceStorage):
 # %%
 # ### Assistant
 #
-# [ragna.core.Assistant][]s are objects that take a list of messages containing one or more user prompts and relevant
-# [ragna.core.Source][]s and generate a response form that. Usually, assistants are
-# LLMs.
+# [ragna.core.Assistant][]s are objects that take the chat history as list of
+# [ragna.core.Messages][]s and their relevant [ragna.core.Source][]s and generate a
+# response form that. Usually, assistants are LLMs.
 #
 # In this tutorial, we define a minimal `TutorialAssistant` that is similar to
 # [ragna.assistants.RagnaDemoAssistant][]. In `.answer()` we mirror back the user
@@ -84,6 +84,8 @@ from ragna.core import Assistant, Source
 class TutorialAssistant(Assistant):
     def answer(self, messages: list[Message]) -> Iterator[str]:
         print(f"Running {type(self).__name__}().answer()")
+        # For simplicity, we only deal with the last message, i.e. the latest user
+        # prompt, here.
         prompt, sources = (message := messages[-1]).content, message.sources
         yield (
             f"To answer the user prompt '{prompt}', "

--- a/docs/tutorials/gallery_custom_components.py
+++ b/docs/tutorials/gallery_custom_components.py
@@ -62,8 +62,8 @@ class TutorialSourceStorage(SourceStorage):
 # ### Assistant
 #
 # [ragna.core.Assistant][]s are objects that take the chat history as list of
-# [ragna.core.Messages][]s and their relevant [ragna.core.Source][]s and generate a
-# response form that. Usually, assistants are LLMs.
+# [ragna.core.Message][]s and their relevant [ragna.core.Source][]s and generate a
+# response from that. Usually, assistants are LLMs.
 #
 # In this tutorial, we define a minimal `TutorialAssistant` that is similar to
 # [ragna.assistants.RagnaDemoAssistant][]. In `.answer()` we mirror back the user
@@ -84,8 +84,8 @@ from ragna.core import Assistant, Source
 class TutorialAssistant(Assistant):
     def answer(self, messages: list[Message]) -> Iterator[str]:
         print(f"Running {type(self).__name__}().answer()")
-        # For simplicity, we only deal with the last message, i.e. the latest user
-        # prompt, here.
+        # For simplicity, we only deal with the last message here, i.e. the latest user
+        # prompt.
         prompt, sources = (message := messages[-1]).content, message.sources
         yield (
             f"To answer the user prompt '{prompt}', "

--- a/ragna/assistants/_ai21labs.py
+++ b/ragna/assistants/_ai21labs.py
@@ -1,6 +1,6 @@
 from typing import AsyncIterator, cast
 
-from ragna.core import Source
+from ragna.core import Message, Source
 
 from ._http_api import HttpApiAssistant
 
@@ -23,11 +23,12 @@ class Ai21LabsAssistant(HttpApiAssistant):
         return instruction + "\n\n".join(source.content for source in sources)
 
     async def answer(
-        self, prompt: str, sources: list[Source], *, max_new_tokens: int = 256
+        self, messages: list[Message], *, max_new_tokens: int = 256
     ) -> AsyncIterator[str]:
         # See https://docs.ai21.com/reference/j2-chat-api#chat-api-parameters
         # See https://docs.ai21.com/reference/j2-complete-api-ref#api-parameters
         # See https://docs.ai21.com/reference/j2-chat-api#understanding-the-response
+        prompt, sources = (message := messages[-1]).content, message.sources
         async for data in self._call_api(
             "POST",
             f"https://api.ai21.com/studio/v1/j2-{self._MODEL_TYPE}/chat",

--- a/ragna/assistants/_anthropic.py
+++ b/ragna/assistants/_anthropic.py
@@ -1,6 +1,6 @@
 from typing import AsyncIterator, cast
 
-from ragna.core import PackageRequirement, RagnaException, Requirement, Source
+from ragna.core import Message, PackageRequirement, RagnaException, Requirement, Source
 
 from ._http_api import HttpApiAssistant, HttpStreamingProtocol
 
@@ -37,10 +37,11 @@ class AnthropicAssistant(HttpApiAssistant):
         )
 
     async def answer(
-        self, prompt: str, sources: list[Source], *, max_new_tokens: int = 256
+        self, messages: list[Message], *, max_new_tokens: int = 256
     ) -> AsyncIterator[str]:
         # See https://docs.anthropic.com/claude/reference/messages_post
         # See https://docs.anthropic.com/claude/reference/streaming
+        prompt, sources = (message := messages[-1]).content, message.sources
         async for data in self._call_api(
             "POST",
             "https://api.anthropic.com/v1/messages",

--- a/ragna/assistants/_cohere.py
+++ b/ragna/assistants/_cohere.py
@@ -1,6 +1,6 @@
 from typing import AsyncIterator, cast
 
-from ragna.core import RagnaException, Source
+from ragna.core import Message, RagnaException, Source
 
 from ._http_api import HttpApiAssistant, HttpStreamingProtocol
 
@@ -25,11 +25,12 @@ class CohereAssistant(HttpApiAssistant):
         return [{"title": source.id, "snippet": source.content} for source in sources]
 
     async def answer(
-        self, prompt: str, sources: list[Source], *, max_new_tokens: int = 256
+        self, messages: list[Message], *, max_new_tokens: int = 256
     ) -> AsyncIterator[str]:
         # See https://docs.cohere.com/docs/cochat-beta
         # See https://docs.cohere.com/reference/chat
         # See https://docs.cohere.com/docs/retrieval-augmented-generation-rag
+        prompt, sources = (message := messages[-1]).content, message.sources
         async for event in self._call_api(
             "POST",
             "https://api.cohere.ai/v1/chat",

--- a/ragna/assistants/_demo.py
+++ b/ragna/assistants/_demo.py
@@ -36,7 +36,7 @@ class RagnaDemoAssistant(Assistant):
         ).strip()
 
     def _default_answer(self, messages: list[Message]) -> str:
-        prompt = messages[0].content.strip()
+        prompt = messages[-1].content.strip()
         sources_display = []
         for message in messages:
             sources = message.sources

--- a/ragna/assistants/_demo.py
+++ b/ragna/assistants/_demo.py
@@ -39,9 +39,8 @@ class RagnaDemoAssistant(Assistant):
         ).strip()
 
     def _default_answer(self, messages: list[Message]) -> str:
-        prompt = messages[-1].content.strip()
+        prompt, sources = (message := messages[-1]).content, message.sources
         sources_display = []
-        sources = messages[-1].sources
         for source in sources:
             source_display = f"- {source.document.name}"
             if source.location:

--- a/ragna/assistants/_demo.py
+++ b/ragna/assistants/_demo.py
@@ -1,8 +1,7 @@
-import re
 import textwrap
 from typing import Iterator
 
-from ragna.core import Assistant, Source
+from ragna.core import Assistant, Message
 
 
 class RagnaDemoAssistant(Assistant):
@@ -22,11 +21,8 @@ class RagnaDemoAssistant(Assistant):
     def display_name(cls) -> str:
         return "Ragna/DemoAssistant"
 
-    def answer(self, prompt: str, sources: list[Source]) -> Iterator[str]:
-        if re.search("markdown", prompt, re.IGNORECASE):
-            yield self._markdown_answer()
-        else:
-            yield self._default_answer(prompt, sources)
+    def answer(self, messages: list[Message]) -> Iterator[str]:
+        yield self._default_answer(messages)
 
     def _markdown_answer(self) -> str:
         return textwrap.dedent(
@@ -39,16 +35,19 @@ class RagnaDemoAssistant(Assistant):
             """
         ).strip()
 
-    def _default_answer(self, prompt: str, sources: list[Source]) -> str:
+    def _default_answer(self, messages: list[Message]) -> str:
+        prompt = messages[0].content.strip()
         sources_display = []
-        for source in sources:
-            source_display = f"- {source.document.name}"
-            if source.location:
-                source_display += f", {source.location}"
-            source_display += f": {textwrap.shorten(source.content, width=100)}"
-            sources_display.append(source_display)
-        if len(sources) > 3:
-            sources_display.append("[...]")
+        for message in messages:
+            sources = message.sources
+            for source in sources:
+                source_display = f"- {source.document.name}"
+                if source.location:
+                    source_display += f", {source.location}"
+                source_display += f": {textwrap.shorten(source.content, width=100)}"
+                sources_display.append(source_display)
+            if len(sources) > 3:
+                sources_display.append("[...]")
 
         return (
             textwrap.dedent(

--- a/ragna/assistants/_demo.py
+++ b/ragna/assistants/_demo.py
@@ -24,7 +24,8 @@ class RagnaDemoAssistant(Assistant):
     def answer(self, messages: list[Message]) -> Iterator[str]:
         if "markdown" in messages[-1].content.lower():
             yield self._markdown_answer()
-        yield self._default_answer(messages)
+        else:
+            yield self._default_answer(messages)
 
     def _markdown_answer(self) -> str:
         return textwrap.dedent(

--- a/ragna/assistants/_demo.py
+++ b/ragna/assistants/_demo.py
@@ -22,6 +22,8 @@ class RagnaDemoAssistant(Assistant):
         return "Ragna/DemoAssistant"
 
     def answer(self, messages: list[Message]) -> Iterator[str]:
+        if "markdown" in messages[-1].content.lower():
+            yield self._markdown_answer()
         yield self._default_answer(messages)
 
     def _markdown_answer(self) -> str:

--- a/ragna/assistants/_demo.py
+++ b/ragna/assistants/_demo.py
@@ -1,7 +1,7 @@
 import textwrap
 from typing import Iterator
 
-from ragna.core import Assistant, Message
+from ragna.core import Assistant, Message, MessageRole
 
 
 class RagnaDemoAssistant(Assistant):
@@ -38,24 +38,26 @@ class RagnaDemoAssistant(Assistant):
     def _default_answer(self, messages: list[Message]) -> str:
         prompt = messages[-1].content.strip()
         sources_display = []
-        for message in messages:
-            sources = message.sources
-            for source in sources:
-                source_display = f"- {source.document.name}"
-                if source.location:
-                    source_display += f", {source.location}"
-                source_display += f": {textwrap.shorten(source.content, width=100)}"
-                sources_display.append(source_display)
-            if len(sources) > 3:
-                sources_display.append("[...]")
+        sources = messages[-1].sources
+        for source in sources:
+            source_display = f"- {source.document.name}"
+            if source.location:
+                source_display += f", {source.location}"
+            source_display += f": {textwrap.shorten(source.content, width=100)}"
+            sources_display.append(source_display)
+        if len(sources) > 3:
+            sources_display.append("[...]")
 
+        n_messages = len([m for m in messages if m.role == MessageRole.USER])
         return (
             textwrap.dedent(
                 """
-                I'm a demo assistant and can be used to try Ragnas workflow.
+                I'm a demo assistant and can be used to try Ragna's workflow.
                 I will only mirror back my inputs. 
+
+                So far I have received {n_messages} messages.
                 
-                Your prompt was:
+                Your last prompt was:
 
                 > {prompt}
 
@@ -65,5 +67,10 @@ class RagnaDemoAssistant(Assistant):
                 """
             )
             .strip()
-            .format(name=str(self), prompt=prompt, sources="\n".join(sources_display))
+            .format(
+                name=str(self),
+                n_messages=n_messages,
+                prompt=prompt,
+                sources="\n".join(sources_display),
+            )
         )

--- a/ragna/assistants/_google.py
+++ b/ragna/assistants/_google.py
@@ -1,6 +1,6 @@
 from typing import AsyncIterator
 
-from ragna.core import Source
+from ragna.core import Message, Source
 
 from ._http_api import HttpApiAssistant, HttpStreamingProtocol
 
@@ -26,8 +26,9 @@ class GoogleAssistant(HttpApiAssistant):
         )
 
     async def answer(
-        self, prompt: str, sources: list[Source], *, max_new_tokens: int = 256
+        self, messages: list[Message], *, max_new_tokens: int = 256
     ) -> AsyncIterator[str]:
+        prompt, sources = (message := messages[-1]).content, message.sources
         async for chunk in self._call_api(
             "POST",
             f"https://generativelanguage.googleapis.com/v1beta/models/{self._MODEL}:streamGenerateContent",

--- a/ragna/assistants/_ollama.py
+++ b/ragna/assistants/_ollama.py
@@ -2,7 +2,7 @@ import os
 from functools import cached_property
 from typing import AsyncIterator, cast
 
-from ragna.core import RagnaException, Source
+from ragna.core import Message, RagnaException
 
 from ._http_api import HttpStreamingProtocol
 from ._openai import OpenaiLikeHttpApiAssistant
@@ -30,8 +30,9 @@ class OllamaAssistant(OpenaiLikeHttpApiAssistant):
         return f"{base_url}/api/chat"
 
     async def answer(
-        self, prompt: str, sources: list[Source], *, max_new_tokens: int = 256
+        self, messages: list[Message], *, max_new_tokens: int = 256
     ) -> AsyncIterator[str]:
+        prompt, sources = (message := messages[-1]).content, message.sources
         async for data in self._stream(prompt, sources, max_new_tokens=max_new_tokens):
             # Modeled after
             # https://github.com/ollama/ollama/blob/06a1508bfe456e82ba053ea554264e140c5057b5/examples/python-loganalysis/readme.md?plain=1#L57-L62

--- a/ragna/assistants/_ollama.py
+++ b/ragna/assistants/_ollama.py
@@ -32,10 +32,8 @@ class OllamaAssistant(OpenaiLikeHttpApiAssistant):
     async def answer(
         self, messages: list[Message], *, max_new_tokens: int = 256
     ) -> AsyncIterator[str]:
-        formatted_messages = await self._format_message_sources(messages)
-        async for data in self._stream(
-            formatted_messages, max_new_tokens=max_new_tokens
-        ):
+        prompt, sources = (message := messages[-1]).content, message.sources
+        async for data in self._stream(prompt, sources, max_new_tokens=max_new_tokens):
             # Modeled after
             # https://github.com/ollama/ollama/blob/06a1508bfe456e82ba053ea554264e140c5057b5/examples/python-loganalysis/readme.md?plain=1#L57-L62
             if "error" in data:

--- a/ragna/assistants/_ollama.py
+++ b/ragna/assistants/_ollama.py
@@ -32,8 +32,10 @@ class OllamaAssistant(OpenaiLikeHttpApiAssistant):
     async def answer(
         self, messages: list[Message], *, max_new_tokens: int = 256
     ) -> AsyncIterator[str]:
-        prompt, sources = (message := messages[-1]).content, message.sources
-        async for data in self._stream(prompt, sources, max_new_tokens=max_new_tokens):
+        formatted_messages = await self._format_message_sources(messages)
+        async for data in self._stream(
+            formatted_messages, max_new_tokens=max_new_tokens
+        ):
             # Modeled after
             # https://github.com/ollama/ollama/blob/06a1508bfe456e82ba053ea554264e140c5057b5/examples/python-loganalysis/readme.md?plain=1#L57-L62
             if "error" in data:

--- a/ragna/assistants/_openai.py
+++ b/ragna/assistants/_openai.py
@@ -14,7 +14,9 @@ class OpenaiLikeHttpApiAssistant(HttpApiAssistant):
     @abc.abstractmethod
     def _url(self) -> str: ...
 
-    async def _format_message_sources(self, messages: list[Message]) -> str:
+    async def _format_message_sources(
+        self, messages: list[Message]
+    ) -> list[dict[str, str]]:
         # TODO: move to user config
         instruction = (
             "You are a helpful assistant that answers user questions given the context below. "

--- a/ragna/assistants/_openai.py
+++ b/ragna/assistants/_openai.py
@@ -78,6 +78,7 @@ class OpenaiLikeHttpApiAssistant(HttpApiAssistant):
         max_new_tokens: int = 256,
     ) -> AsyncIterator[str]:
         formatted_messages = self._format_message_sources(messages)
+        print("formatted_messages: ", formatted_messages)
         async for data in self._stream(
             formatted_messages, max_new_tokens=max_new_tokens
         ):

--- a/ragna/assistants/_openai.py
+++ b/ragna/assistants/_openai.py
@@ -28,10 +28,11 @@ class OpenaiLikeHttpApiAssistant(HttpApiAssistant):
             role=MessageRole.SYSTEM,
         )
 
-    def _format_message_sources(self, messages: list[Message]) -> str:
+    async def _format_message_sources(self, messages: list[Message]) -> str:
         sources_prompt = "Include the following sources in your answer:"
         formatted_messages = []
         for message in messages:
+            content = await message.read()
             if message.role == MessageRole.USER:
                 formatted_messages.append(
                     {
@@ -41,9 +42,7 @@ class OpenaiLikeHttpApiAssistant(HttpApiAssistant):
                     }
                 )
 
-            formatted_messages.append(
-                {"content": message.content, "role": message.role}
-            )
+            formatted_messages.append({"content": content, "role": message.role})
         return formatted_messages
 
     def _stream(
@@ -77,7 +76,7 @@ class OpenaiLikeHttpApiAssistant(HttpApiAssistant):
         *,
         max_new_tokens: int = 256,
     ) -> AsyncIterator[str]:
-        formatted_messages = self._format_message_sources(messages)
+        formatted_messages = await self._format_message_sources(messages)
         print("formatted_messages: ", formatted_messages)
         async for data in self._stream(
             formatted_messages, max_new_tokens=max_new_tokens

--- a/ragna/core/_components.py
+++ b/ragna/core/_components.py
@@ -238,14 +238,12 @@ class Assistant(Component, abc.ABC):
     __ragna_protocol_methods__ = ["answer"]
 
     @abc.abstractmethod
-    def answer(
-        self,
-        messages: list[Message] = [],
-    ) -> Iterator[str]:
-        """Answer a prompt given some sources.
+    def answer(self, messages: list[Message]) -> Iterator[str]:
+        """Answer a prompt given the chat history.
 
         Args:
-            messages: List of messages to send to the LLM API.
+            messages: List of messages in the chat history. The last item is the current
+                user prompt and has the relevant sources attached to it.
 
         Returns:
             Answer.

--- a/ragna/core/_components.py
+++ b/ragna/core/_components.py
@@ -147,7 +147,7 @@ class SourceStorage(Component, abc.ABC):
         ...
 
 
-class MessageRole(enum.Enum):
+class MessageRole(str, enum.Enum):
     """Message role
 
     Attributes:
@@ -237,13 +237,25 @@ class Assistant(Component, abc.ABC):
 
     __ragna_protocol_methods__ = ["answer"]
 
+    def _make_system_content(self):
+        return Message(
+            content=(
+                "You are a helpful assistant that answers user questions given the context below. "
+                "If you don't know the answer, just say so. Don't try to make up an answer. "
+                "Only use the included messages below to generate the answer."
+            ),
+            role=MessageRole.SYSTEM,
+        )
+
     @abc.abstractmethod
-    def answer(self, prompt: str, sources: list[Source]) -> Iterator[str]:
+    def answer(
+        self,
+        messages: list[Message] = [],
+    ) -> Iterator[str]:
         """Answer a prompt given some sources.
 
         Args:
-            prompt: Prompt to be answered.
-            sources: Sources to use when answering answer the prompt.
+            messages: List of messages to send to the LLM API.
 
         Returns:
             Answer.

--- a/ragna/core/_components.py
+++ b/ragna/core/_components.py
@@ -185,8 +185,10 @@ class Message:
     ) -> None:
         if isinstance(content, str):
             self._content: str = content
+            print("content", content)
         else:
             self._content_stream: AsyncIterable[str] = content
+            print("content_stream", content)
 
         self.role = role
         self.sources = sources or []

--- a/ragna/core/_components.py
+++ b/ragna/core/_components.py
@@ -239,16 +239,6 @@ class Assistant(Component, abc.ABC):
 
     __ragna_protocol_methods__ = ["answer"]
 
-    def _make_system_content(self):
-        return Message(
-            content=(
-                "You are a helpful assistant that answers user questions given the context below. "
-                "If you don't know the answer, just say so. Don't try to make up an answer. "
-                "Only use the included messages below to generate the answer."
-            ),
-            role=MessageRole.SYSTEM,
-        )
-
     @abc.abstractmethod
     def answer(
         self,

--- a/ragna/core/_components.py
+++ b/ragna/core/_components.py
@@ -185,10 +185,8 @@ class Message:
     ) -> None:
         if isinstance(content, str):
             self._content: str = content
-            print("content", content)
         else:
             self._content_stream: AsyncIterable[str] = content
-            print("content_stream", content)
 
         self.role = role
         self.sources = sources or []

--- a/ragna/core/_rag.py
+++ b/ragna/core/_rag.py
@@ -234,8 +234,9 @@ class Chat:
             sources=sources,
         )
 
-        if not stream:
-            await answer.read()
+        await answer.read()
+        # if not stream:
+        #     await answer.read()
 
         self._messages.append(answer)
 

--- a/ragna/core/_rag.py
+++ b/ragna/core/_rag.py
@@ -234,9 +234,9 @@ class Chat:
             sources=sources,
         )
 
-        await answer.read()
-        # if not stream:
-        #     await answer.read()
+        # await answer.read()
+        if not stream:
+            await answer.read()
 
         self._messages.append(answer)
 

--- a/ragna/core/_rag.py
+++ b/ragna/core/_rag.py
@@ -195,9 +195,6 @@ class Chat:
         await self._run(self.source_storage.store, self.documents)
         self._prepared = True
 
-        system_prompt = self.assistant._make_system_content()
-        self._messages.append(system_prompt)
-
         welcome = Message(
             content="How can I help you with the documents?",
             role=MessageRole.SYSTEM,

--- a/ragna/core/_rag.py
+++ b/ragna/core/_rag.py
@@ -226,11 +226,10 @@ class Chat:
         self._messages.append(question)
 
         answer = Message(
-            content=self._run_gen(self.assistant.answer, self._messages[:]),
+            content=self._run_gen(self.assistant.answer, self._messages.copy()),
             role=MessageRole.ASSISTANT,
             sources=sources,
         )
-
         if not stream:
             await answer.read()
 

--- a/ragna/core/_rag.py
+++ b/ragna/core/_rag.py
@@ -229,12 +229,11 @@ class Chat:
         self._messages.append(question)
 
         answer = Message(
-            content=self._run_gen(self.assistant.answer, self._messages),
+            content=self._run_gen(self.assistant.answer, self._messages[:]),
             role=MessageRole.ASSISTANT,
             sources=sources,
         )
 
-        # await answer.read()
         if not stream:
             await answer.read()
 

--- a/ragna/deploy/_api/core.py
+++ b/ragna/deploy/_api/core.py
@@ -109,7 +109,6 @@ def app(*, config: Config, ignore_unavailable_components: bool) -> FastAPI:
     def _get_component_json_schema(
         component: Type[Component],
     ) -> dict[str, dict[str, Any]]:
-        print(component._protocol_model())
         json_schema = component._protocol_model().model_json_schema()
         # FIXME: there is likely a better way to exclude certain fields builtin in
         #  pydantic

--- a/ragna/deploy/_api/core.py
+++ b/ragna/deploy/_api/core.py
@@ -109,6 +109,7 @@ def app(*, config: Config, ignore_unavailable_components: bool) -> FastAPI:
     def _get_component_json_schema(
         component: Type[Component],
     ) -> dict[str, dict[str, Any]]:
+        print(component._protocol_model())
         json_schema = component._protocol_model().model_json_schema()
         # FIXME: there is likely a better way to exclude certain fields builtin in
         #  pydantic

--- a/tests/assistants/test_api.py
+++ b/tests/assistants/test_api.py
@@ -5,7 +5,7 @@ import pytest
 from ragna import assistants
 from ragna._compat import anext
 from ragna.assistants._http_api import HttpApiAssistant
-from ragna.core import RagnaException
+from ragna.core import Message, RagnaException
 from tests.utils import skip_on_windows
 
 HTTP_API_ASSISTANTS = [
@@ -25,7 +25,8 @@ HTTP_API_ASSISTANTS = [
 async def test_api_call_error_smoke(mocker, assistant):
     mocker.patch.dict(os.environ, {assistant._API_KEY_ENV_VAR: "SENTINEL"})
 
-    chunks = assistant().answer(prompt="?", sources=[])
+    messages = [Message(content="?", sources=[])]
+    chunks = assistant().answer(messages)
 
     with pytest.raises(RagnaException, match="API call failed"):
         await anext(chunks)

--- a/tests/core/test_rag.py
+++ b/tests/core/test_rag.py
@@ -45,8 +45,7 @@ class TestChat:
         class ValidationAssistant(Assistant):
             def answer(
                 self,
-                prompt,
-                sources,
+                messages,
                 bool_param: bool,
                 int_param: int,
                 float_param: float,
@@ -65,8 +64,7 @@ class TestChat:
         class ValidationAssistant(Assistant):
             def answer(
                 self,
-                prompt,
-                sources,
+                messages,
                 bool_param: bool,
                 int_param: int,
                 float_param: float,

--- a/tests/deploy/api/test_e2e.py
+++ b/tests/deploy/api/test_e2e.py
@@ -6,10 +6,11 @@ from fastapi.testclient import TestClient
 from ragna.deploy import Config
 from ragna.deploy._api import app
 from tests.deploy.utils import TestAssistant, authenticate_with_api
-from tests.utils import skip_on_windows
+
+# from tests.utils import skip_on_windows
 
 
-@skip_on_windows
+# @skip_on_windows
 @pytest.mark.parametrize("multiple_answer_chunks", [True, False])
 @pytest.mark.parametrize("stream_answer", [True, False])
 def test_e2e(tmp_local_root, multiple_answer_chunks, stream_answer):

--- a/tests/deploy/api/test_e2e.py
+++ b/tests/deploy/api/test_e2e.py
@@ -6,8 +6,10 @@ from fastapi.testclient import TestClient
 from ragna.deploy import Config
 from ragna.deploy._api import app
 from tests.deploy.utils import TestAssistant, authenticate_with_api
+from tests.utils import skip_on_windows
 
 
+@skip_on_windows
 @pytest.mark.parametrize("multiple_answer_chunks", [True, False])
 @pytest.mark.parametrize("stream_answer", [True, False])
 def test_e2e(tmp_local_root, multiple_answer_chunks, stream_answer):

--- a/tests/deploy/api/test_e2e.py
+++ b/tests/deploy/api/test_e2e.py
@@ -107,12 +107,12 @@ def test_e2e(tmp_local_root, multiple_answer_chunks, stream_answer):
 
         chat = client.get(f"/chats/{chat['id']}").raise_for_status().json()
         assert len(chat["messages"]) == 3
+        assert chat["messages"][-1] == message
         assert (
             chat["messages"][-2]["role"] == "user"
             and chat["messages"][-2]["sources"] == message["sources"]
             and chat["messages"][-2]["content"] == prompt
         )
-        assert chat["messages"][-1] == message
 
         client.delete(f"/chats/{chat['id']}").raise_for_status()
         assert client.get("/chats").raise_for_status().json() == []

--- a/tests/deploy/api/test_e2e.py
+++ b/tests/deploy/api/test_e2e.py
@@ -109,7 +109,7 @@ def test_e2e(tmp_local_root, multiple_answer_chunks, stream_answer):
         assert len(chat["messages"]) == 3
         assert (
             chat["messages"][-2]["role"] == "user"
-            and chat["messages"][-2]["sources"] == []
+            and chat["messages"][-2]["sources"] == message["sources"]
             and chat["messages"][-2]["content"] == prompt
         )
         assert chat["messages"][-1] == message

--- a/tests/deploy/api/test_e2e.py
+++ b/tests/deploy/api/test_e2e.py
@@ -6,11 +6,10 @@ from fastapi.testclient import TestClient
 from ragna.deploy import Config
 from ragna.deploy._api import app
 from tests.deploy.utils import TestAssistant, authenticate_with_api
+from tests.utils import skip_on_windows
 
-# from tests.utils import skip_on_windows
 
-
-# @skip_on_windows
+@skip_on_windows
 @pytest.mark.parametrize("multiple_answer_chunks", [True, False])
 @pytest.mark.parametrize("stream_answer", [True, False])
 def test_e2e(tmp_local_root, multiple_answer_chunks, stream_answer):

--- a/tests/deploy/utils.py
+++ b/tests/deploy/utils.py
@@ -8,7 +8,7 @@ from ragna.core._utils import default_user
 
 
 class TestAssistant(RagnaDemoAssistant):
-    def answer(self, prompt, sources, *, multiple_answer_chunks: bool = True):
+    def answer(self, messages, *, multiple_answer_chunks: bool = True):
         # Simulate a "real" assistant through a small delay. See
         # https://github.com/Quansight/ragna/pull/401#issuecomment-2095851440
         # for why this is needed.
@@ -17,7 +17,7 @@ class TestAssistant(RagnaDemoAssistant):
         # the tests in deploy/ui/test_ui.py. This can be removed if TestAssistant
         # is ever removed from that file.
         time.sleep(1e-3)
-        content = next(super().answer(prompt, sources))
+        content = next(super().answer(messages))
 
         if multiple_answer_chunks:
             for chunk in content.split(" "):


### PR DESCRIPTION
This is a very rough first pass at https://github.com/Quansight/ragna/issues/421. I decided to investigate the naive approach of replacing
```python
class Assistant
    ...
    def answer(self, prompt: str, sources: list[Source]):
        ...
```
with
```python
class Assistant
    ...
    def answer(self, messages: list[Message]):
        ...
```
for just the HTTP-like assistants as a POC. Since a `Message` instance can hold a list of `Source`s, the `_messages` list in `Rag.Chat` serves as a cache of raw messages that live in the database (and what the user sees), while each assistant is responsible for formatting the message list according to the needs of the individual LLM.