### PR TITLE
PoC for Ragna meta package

### DIFF
--- a/meta-package/pyproject.toml
+++ b/meta-package/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = [
+    "setuptools>=64",
+    "setuptools_scm>=8",
+    "tomlkit; python_version<'3.11'"
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "Ragna"
+description = "RAG orchestration framework"
+license = {file = "LICENSE"}
+authors = [
+    { name = "Ragna Development Team", email = "connect@quansight.com" },
+]
+readme = "README.md"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+]
+requires-python = ">=3.9"
+dynamic = ["version", "dependencies"]
+
+[project.urls]
+Homepage = "https://ragna.chat"
+Documentation = "https://ragna.chat"
+Changelog = "https://ragna.chat/en/stable/references/release-notes/"
+Repository = "https://github.com/Quansight/ragna"
+
+[tool.setuptools_scm]
+root = ".."
+version_scheme = "release-branch-semver"
+local_scheme = "node-and-date"

--- a/meta-package/setup.py
+++ b/meta-package/setup.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from setuptools import setup
+from setuptools_scm import Configuration, get_version
+
+HERE = Path(__file__).parent
+PROJECT_ROOT = HERE.parent
+
+
+config = Configuration.from_file(PROJECT_ROOT / "pyproject.toml")
+version = get_version(
+    root=str(PROJECT_ROOT),
+    version_scheme=config.version_scheme,
+    local_scheme=config.local_scheme,
+)
+install_requires = [f"{config.dist_name}=={version}"]
+
+with open(PROJECT_ROOT / "requirements-optional.txt") as file:
+    install_requires.extend(file.read().splitlines())
+
+
+setup(install_requires=install_requires)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,13 @@
 [build-system]
 requires = [
-    "setuptools>=45",
-    "setuptools_scm[toml]>=6.2",
+    "setuptools>=64",
+    "setuptools_scm>=8",
+    "tomlkit; python_version<'3.11'",
 ]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "Ragna"
+name = "ragna-base"
 description = "RAG orchestration framework"
 license = {file = "LICENSE"}
 authors = [
@@ -50,24 +51,10 @@ Documentation = "https://ragna.chat"
 Changelog = "https://ragna.chat/en/stable/references/release-notes/"
 Repository = "https://github.com/Quansight/ragna"
 
-[project.optional-dependencies]
-# to update the array below, run scripts/update_optional_dependencies.py
-all = [
-    "chromadb>=0.4.13",
-    "httpx_sse",
-    "ijson",
-    "lancedb>=0.2",
-    "pyarrow",
-    "pymupdf>=1.23.6",
-    "python-docx",
-    "python-pptx",
-    "tiktoken",
-]
-
 [tool.setuptools_scm]
 write_to = "ragna/_version.py"
 version_scheme = "release-branch-semver"
-local_scheme = "node-and-timestamp"
+local_scheme = "node-and-date"
 
 [project.scripts]
 ragna = "ragna.__main__:app"

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,0 +1,9 @@
+chromadb>=0.4.13
+httpx_sse
+ijson
+lancedb>=0.2
+pyarrow
+pymupdf>=1.23.6
+python-docx
+python-pptx
+tiktoken


### PR DESCRIPTION
This is an alternative to #405. With this we have a new folder `meta-package` that contains a `pyproject.toml` and a `setup.py`:

- The `pyproject.toml` is minimal version of the one we have in our project root. We should have a CI job that makes sure both are in sync.
- The `setup.py` does nothing but injects the optional dependencies and `ragna_base` as requirements for the meta package.

Here is how you do a development install

```shell
$ # install ragna-base
$ pip install -e .
$ # either install the meta package
$ pip install -e ./meta-package
$ # or just install the optional requirements
$ pip install -r requirements-optional.txt
```

To release you can do

```shell
$ # build ragna-base
$ python -m build
$ # build ragna
$ python -m build --sdist --wheel --output-dir ./dist ./meta-package
```

I don't know why I explicitly need to set `--sdist --wheel` for the meta-package build. If I don't, the  build errors. This seems to be a bug in the `build` package. Will look into it.