### PR TITLE
remove redis as dependency

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -53,11 +53,6 @@ runs:
         mamba env update --file environment-dev.yml
         git checkout -- environment-dev.yml
 
-    - name: Install redis-server if necessary
-      if: (steps.cache.outputs.cache-hit != 'true') && (runner.os != 'Windows')
-      shell: bash -el {0}
-      run: mamba install --yes --channel conda-forge redis-server
-
     - name: Install playwright
       shell: bash -el {0}
       run: playwright install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
     "pydantic-settings>=2",
     "PyJWT",
     "python-multipart",
-    "redis",
     "questionary",
     "rich",
     "sqlalchemy>=2",

--- a/requirements-docker.lock
+++ b/requirements-docker.lock
@@ -304,8 +304,6 @@ questionary==2.0.1
     # via Ragna (pyproject.toml)
 ratelimiter==1.2.0.post0
     # via lancedb
-redis==5.0.1
-    # via Ragna (pyproject.toml)
 regex==2023.12.25
     # via tiktoken
 requests==2.31.0


### PR DESCRIPTION
While working on #441, I noticed that for whatever reason still had a hard-dependency on redis. This dates back to before v0.1.0 and was probably just missed. In any case, we currently don't use redis and if we do in the future, it will likely not be a hard dependency. Thus, we remove it for now.