### PR TITLE
#391 Chat Ordering based upon the order of interaction

### DIFF
--- a/ragna/deploy/_ui/left_sidebar.py
+++ b/ragna/deploy/_ui/left_sidebar.py
@@ -60,8 +60,7 @@ class LeftSidebar(pn.viewable.Viewer):
     @pn.depends("refresh_counter", "chats", "current_chat_id", on_init=True)
     def __panel__(self):
         self.chats.sort(
-            key=lambda chat: chat['messages'][-1]['timestamp'],
-            reverse=True
+            key=lambda chat: chat['messages'][-1]['timestamp'], reverse=True
         )
 
         self.chat_buttons = []

--- a/ragna/deploy/_ui/left_sidebar.py
+++ b/ragna/deploy/_ui/left_sidebar.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import panel as pn
 import param
 
@@ -59,13 +61,12 @@ class LeftSidebar(pn.viewable.Viewer):
 
     @pn.depends("refresh_counter", "chats", "current_chat_id", on_init=True)
     def __panel__(self):
-        from datetime import datetime
         epoch = datetime(1970, 1, 1)
         self.chats.sort(
             key=lambda chat: (
                 epoch if not chat["messages"] else chat["messages"][-1]["timestamp"]
             ),
-            reverse=True
+            reverse=True,
         )
 
         self.chat_buttons = []

--- a/ragna/deploy/_ui/left_sidebar.py
+++ b/ragna/deploy/_ui/left_sidebar.py
@@ -60,7 +60,7 @@ class LeftSidebar(pn.viewable.Viewer):
     @pn.depends("refresh_counter", "chats", "current_chat_id", on_init=True)
     def __panel__(self):
         self.chats.sort(
-            key=lambda chat: chat['messages'][-1]['timestamp'], reverse=True
+            key=lambda chat: chat["messages"][-1]["timestamp"], reverse=True
         )
 
         self.chat_buttons = []

--- a/ragna/deploy/_ui/left_sidebar.py
+++ b/ragna/deploy/_ui/left_sidebar.py
@@ -59,8 +59,13 @@ class LeftSidebar(pn.viewable.Viewer):
 
     @pn.depends("refresh_counter", "chats", "current_chat_id", on_init=True)
     def __panel__(self):
+        from datetime import datetime
+        epoch = datetime(1970, 1, 1)
         self.chats.sort(
-            key=lambda chat: chat["messages"][-1]["timestamp"], reverse=True
+            key=lambda chat: (
+                epoch if not chat["messages"] else chat["messages"][-1]["timestamp"]
+            ),
+            reverse=True
         )
 
         self.chat_buttons = []

--- a/ragna/deploy/_ui/left_sidebar.py
+++ b/ragna/deploy/_ui/left_sidebar.py
@@ -60,7 +60,7 @@ class LeftSidebar(pn.viewable.Viewer):
     @pn.depends("refresh_counter", "chats", "current_chat_id", on_init=True)
     def __panel__(self):
         self.chat_buttons = []
-        for chat in self.chats:
+        for chat in reversed(self.chats):
             button = pn.widgets.Button(
                 name=chat["metadata"]["name"],
                 css_classes=["chat_button"],

--- a/ragna/deploy/_ui/left_sidebar.py
+++ b/ragna/deploy/_ui/left_sidebar.py
@@ -59,7 +59,10 @@ class LeftSidebar(pn.viewable.Viewer):
 
     @pn.depends("refresh_counter", "chats", "current_chat_id", on_init=True)
     def __panel__(self):
-        self.chats.sort(key=lambda chat: chat['messages'][-1]['timestamp'], reverse=True)
+        self.chats.sort(
+            key=lambda chat: chat['messages'][-1]['timestamp'],
+            reverse=True
+        )
 
         self.chat_buttons = []
         for chat in self.chats:

--- a/ragna/deploy/_ui/left_sidebar.py
+++ b/ragna/deploy/_ui/left_sidebar.py
@@ -59,8 +59,10 @@ class LeftSidebar(pn.viewable.Viewer):
 
     @pn.depends("refresh_counter", "chats", "current_chat_id", on_init=True)
     def __panel__(self):
+        self.chats.sort(key=lambda chat: chat['messages'][-1]['timestamp'], reverse=True)
+
         self.chat_buttons = []
-        for chat in reversed(self.chats):
+        for chat in self.chats:
             button = pn.widgets.Button(
                 name=chat["metadata"]["name"],
                 css_classes=["chat_button"],


### PR DESCRIPTION
This PR modifies the `LeftSidebar` component to display chats in reverse order, showing the newest chats first instead of the oldest.
Should fix #391 