### PR TITLE
#211 Enable users to upload folders with `file_uploader` component in…

### DIFF
--- a/ragna/deploy/_ui/components/file_uploader.py
+++ b/ragna/deploy/_ui/components/file_uploader.py
@@ -153,6 +153,7 @@ class FileUploader(ReactiveHTML, Widget):  # type: ignore[misc]
                             multiple
                             onchange="${script('file_input_on_change')}" 
                             accept="${allowed_documents_str}"
+                            webkitdirectory
                     /> 
                 </div>
                 <div id="fileListContainer" class="fileListContainer">


### PR DESCRIPTION
This PR enhances the `FileUploader` component by adding functionality to allow users to select entire folders for upload. This uses the `webkitdirectory` attribute in the file input element in order to enable users to select folders too & parse all files inside at once.
Should fix #211 