### PR TITLE
#458 Automate Docker Requirements Workflow for PR Creation and Review Requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/DOCKER_ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/DOCKER_ISSUE_TEMPLATE.md
@@ -3,6 +3,7 @@ title: Workflow Failure: docker-requirements
 labels: bug
 ---
 The workflow 'docker-requirements' has failed.
-Please check the details at: [Workflow Run Details](https://github.com/{{ repository }}/actions/runs/{{ run_id }})
+Please check the details at: [Workflow
+Run Details](https://github.com/{{ repository }}/actions/runs/{{ run_id }})
 
 Triggered by: {{ actor }}

--- a/.github/ISSUE_TEMPLATE/DOCKER_ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/DOCKER_ISSUE_TEMPLATE.md
@@ -1,0 +1,8 @@
+---
+title: Workflow Failure: docker-requirements
+labels: bug
+---
+The workflow 'docker-requirements' has failed.
+Please check the details at: https://github.com/{{ repository }}/actions/runs/{{ run_id }}
+
+Triggered by: {{ actor }}

--- a/.github/ISSUE_TEMPLATE/DOCKER_ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/DOCKER_ISSUE_TEMPLATE.md
@@ -3,6 +3,6 @@ title: Workflow Failure: docker-requirements
 labels: bug
 ---
 The workflow 'docker-requirements' has failed.
-Please check the details at: https://github.com/{{ repository }}/actions/runs/{{ run_id }}
+Please check the details at: [Workflow Run Details](https://github.com/{{ repository }}/actions/runs/{{ run_id }})
 
 Triggered by: {{ actor }}

--- a/.github/ISSUE_TEMPLATE/DOCKER_ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/DOCKER_ISSUE_TEMPLATE.md
@@ -2,8 +2,8 @@
 title: Workflow Failure: docker-requirements
 labels: bug
 ---
-The workflow 'docker-requirements' has failed.
-Please check the details at: [Workflow
+
+The workflow 'docker-requirements' has failed. Please check the details at: [Workflow
 Run Details](https://github.com/{{ repository }}/actions/runs/{{ run_id }})
 
 Triggered by: {{ actor }}

--- a/.github/workflows/update-docker-requirements.yml
+++ b/.github/workflows/update-docker-requirements.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   pull-requests: write

--- a/.github/workflows/update-docker-requirements.yml
+++ b/.github/workflows/update-docker-requirements.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+    paths:
+      - ".github/workflows/update-docker-requirements.yml"
+      - "pyproject.toml"
+      - "requirements-docker.lock"
   workflow_dispatch:
 
 permissions:
@@ -44,18 +48,16 @@ jobs:
           echo "needs-update=${NEEDS_UPDATE}" | tee --append $GITHUB_OUTPUT
 
       - name: Get last merged PR info
-        id: pr_info
+        id: pr-info
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           LAST_MERGED_PR=$(gh pr list --repo $GITHUB_REPOSITORY --state closed --json number --jq '.[0].number')
           echo "Last merged PR number: $LAST_MERGED_PR"
-          PR_INFO=$(gh pr view $LAST_MERGED_PR --repo $GITHUB_REPOSITORY --json author,mergedBy --jq '{author: .author.login, mergedBy: .mergedBy.login}')
+          PR_INFO=$(gh pr view $LAST_MERGED_PR --repo $GITHUB_REPOSITORY --json author,mergedBy --jq '{author: .author.login, merger: .mergedBy.login}')
           echo "PR Info: $PR_INFO"
-          echo "pr_author=$(echo $PR_INFO | jq -r .author)" >> $GITHUB_ENV
-          echo "pr_mergedBy=$(echo $PR_INFO | jq -r .mergedBy)" >> $GITHUB_ENV
-          echo "PR Author: $(echo $PR_INFO | jq -r .author)"
-          echo "PR MergedBy: $(echo $PR_INFO | jq -r .mergedBy)"
+          echo "author=$(echo ${PR_INFO} | jq -r .author)" | tee --append $GITHUB_OUTPUT
+          echo "merger=$(echo ${PR_INFO} | jq -r .merger)" | tee --append $GITHUB_OUTPUT
 
       - name: Open a PR to update the requirements
         if: ${{ steps.update.outputs.needs-update }}

--- a/.github/workflows/update-docker-requirements.yml
+++ b/.github/workflows/update-docker-requirements.yml
@@ -32,12 +32,6 @@ jobs:
       - name: Install GitHub CLI
         run: sudo apt-get install gh
 
-      - name: Set up GitHub CLI authentication
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: |
-          gh auth login --with-token <<< $GH_TOKEN
-
       - name: Update docker requirements
         id: update
         run: |
@@ -52,7 +46,7 @@ jobs:
       - name: Get last merged PR info
         id: pr_info
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           LAST_MERGED_PR=$(gh pr list --repo $GITHUB_REPOSITORY --state closed --json number --jq '.[0].number')
           PR_INFO=$(gh pr view $LAST_MERGED_PR --repo $GITHUB_REPOSITORY --json author,mergedBy --jq '{author: .author.login, mergedBy: .mergedBy.login}')

--- a/.github/workflows/update-docker-requirements.yml
+++ b/.github/workflows/update-docker-requirements.yml
@@ -52,8 +52,8 @@ jobs:
           PR_NUMBER=$(gh api \
             -H 'Accept: application/vnd.github+json' \
             /repos/${{ github.repository }}/commits/${{ github.sha }}/pulls \
-            --jq '.[0].number' || echo "none")
-          if [ "${PR_NUMBER}" != "none" ]; then
+            --jq '.[0].number')
+          if [ $? -eq 0 ]; then
             PR_INFO=$(gh pr view ${PR_NUMBER} --json author,mergedBy --jq '{author: .author.login, merger: .mergedBy.login}')
 
             if [ $? -eq 0 ]; then

--- a/.github/workflows/update-docker-requirements.yml
+++ b/.github/workflows/update-docker-requirements.yml
@@ -1,12 +1,9 @@
 name: docker-requirements
 
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/update-docker-requirements.yml"
-      - "pyproject.toml"
-      - "requirements-docker.lock"
-  workflow_dispatch:
+  push:
+    branches:
+      - main
 
 permissions:
   pull-requests: write

--- a/.github/workflows/update-docker-requirements.yml
+++ b/.github/workflows/update-docker-requirements.yml
@@ -49,9 +49,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           LAST_MERGED_PR=$(gh pr list --repo $GITHUB_REPOSITORY --state closed --json number --jq '.[0].number')
+          echo "Last merged PR number: $LAST_MERGED_PR"
           PR_INFO=$(gh pr view $LAST_MERGED_PR --repo $GITHUB_REPOSITORY --json author,mergedBy --jq '{author: .author.login, mergedBy: .mergedBy.login}')
+          echo "PR Info: $PR_INFO"
           echo "pr_author=$(echo $PR_INFO | jq -r .author)" >> $GITHUB_ENV
           echo "pr_mergedBy=$(echo $PR_INFO | jq -r .mergedBy)" >> $GITHUB_ENV
+          echo "PR Author: $(echo $PR_INFO | jq -r .author)"
+          echo "PR MergedBy: $(echo $PR_INFO | jq -r .mergedBy)"
 
       - name: Open a PR to update the requirements
         if: ${{ steps.update.outputs.needs-update }}

--- a/.github/workflows/update-docker-requirements.yml
+++ b/.github/workflows/update-docker-requirements.yml
@@ -13,6 +13,7 @@ on:
 permissions:
   pull-requests: write
   contents: write
+  issues: write
 
 jobs:
   update:
@@ -20,7 +21,7 @@ jobs:
     defaults:
       run:
         shell: bash -el {0}
-
+    
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -85,3 +86,32 @@ jobs:
             [Workflow run details](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
             ${{ steps.pr-check.outputs.author != 'none' && format('cc @{0}', steps.pr-check.outputs.author) || '' }}
           reviewers: ${{ steps.pr-check.outputs.merger }}
+
+  notify-failure:
+    runs-on: ubuntu-latest
+    needs: update
+    if: failure()
+    steps:
+      - name: Create failure issue
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issueTitle = 'Workflow Failure: docker-requirements';
+            const issueBody = `The workflow 'docker-requirements' has failed.
+            Please check the details at: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            `;
+            const { data: issues } = await github.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open'
+            });
+            const existingIssue = issues.find(issue => issue.title === issueTitle);
+            if (!existingIssue) {
+              await github.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: issueTitle,
+                body: issueBody
+              });
+            }

--- a/.github/workflows/update-docker-requirements.yml
+++ b/.github/workflows/update-docker-requirements.yml
@@ -49,6 +49,8 @@ jobs:
 
       - name: Check if commit is associated with a PR
         id: pr-check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           PR_NUMBER=$(gh api \
             -H 'Accept: application/vnd.github+json' \

--- a/.github/workflows/update-docker-requirements.yml
+++ b/.github/workflows/update-docker-requirements.yml
@@ -21,7 +21,7 @@ jobs:
     defaults:
       run:
         shell: bash -el {0}
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/update-docker-requirements.yml
+++ b/.github/workflows/update-docker-requirements.yml
@@ -47,17 +47,27 @@ jobs:
           NEEDS_UPDATE=$(git diff --quiet && echo 'false' || echo 'true')
           echo "needs-update=${NEEDS_UPDATE}" | tee --append $GITHUB_OUTPUT
 
-      - name: Get last merged PR info
-        id: pr-info
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      - name: Check if commit is associated with a PR
+        id: pr-check
         run: |
-          LAST_MERGED_PR=$(gh pr list --repo $GITHUB_REPOSITORY --state closed --json number --jq '.[0].number')
-          echo "Last merged PR number: $LAST_MERGED_PR"
-          PR_INFO=$(gh pr view $LAST_MERGED_PR --repo $GITHUB_REPOSITORY --json author,mergedBy --jq '{author: .author.login, merger: .mergedBy.login}')
-          echo "PR Info: $PR_INFO"
-          echo "author=$(echo ${PR_INFO} | jq -r .author)" | tee --append $GITHUB_OUTPUT
-          echo "merger=$(echo ${PR_INFO} | jq -r .merger)" | tee --append $GITHUB_OUTPUT
+          PR_NUMBER=$(gh api \
+            -H 'Accept: application/vnd.github+json' \
+            /repos/${{ github.repository }}/commits/${{ github.sha }}/pulls \
+            --jq '.[0].number' || echo "none")
+          if [ "${PR_NUMBER}" != "none" ]; then
+            HAS_PR='true'
+            PR_INFO=$(gh pr view ${PR_NUMBER} --json author,mergedBy --jq '{author: .author.login, merger: .mergedBy.login}')
+            AUTHOR=$(echo ${PR_INFO} | jq -r .author)
+            MERGER=$(echo ${PR_INFO} | jq -r .merger)
+          else
+            HAS_PR='false'
+            AUTHOR=${{ github.actor }}
+            MERGER="none"
+          fi
+
+          echo "has-pr=${HAS_PR}" | tee --append $GITHUB_OUTPUT
+          echo "author=${AUTHOR}" | tee --append $GITHUB_OUTPUT
+          echo "merger=${MERGER}" | tee --append $GITHUB_OUTPUT
 
       - name: Open a PR to update the requirements
         if: ${{ steps.update.outputs.needs-update }}
@@ -66,13 +76,9 @@ jobs:
           commit-message: update requirements-docker.lock
           branch: update-docker-requirements
           branch-suffix: timestamp
-          base: ${{ github.head_ref || github.ref_name }}
+          base: main
           title: Update requirements-docker.lock
-          # prettier-ignore
-          body:
-            https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          reviewers: ${{ env.pr_author }},${{ env.pr_mergedBy }}
-
-      - name: Show diff
-        if: ${{ steps.update.outputs.needs-update }}
-        run: git diff --exit-code
+          body: |
+            Automatic update of requirements-docker.lock.
+            [Workflow run details](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          reviewers: ${{ steps.pr-check.outputs.merger }}

--- a/.github/workflows/update-docker-requirements.yml
+++ b/.github/workflows/update-docker-requirements.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Set up GitHub CLI authentication
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           gh auth login --with-token <<< $GH_TOKEN
 
@@ -52,7 +52,7 @@ jobs:
       - name: Get last merged PR info
         id: pr_info
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           LAST_MERGED_PR=$(gh pr list --repo $GITHUB_REPOSITORY --state closed --json number --jq '.[0].number')
           PR_INFO=$(gh pr view $LAST_MERGED_PR --repo $GITHUB_REPOSITORY --json author,mergedBy --jq '{author: .author.login, mergedBy: .mergedBy.login}')

--- a/.github/workflows/update-docker-requirements.yml
+++ b/.github/workflows/update-docker-requirements.yml
@@ -83,5 +83,5 @@ jobs:
           body: |
             Automatic update of requirements-docker.lock.
             [Workflow run details](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
-            ${{ steps.pr-check.outputs['cc-author'] }}
+            ${{ steps.pr-check.outputs.author != 'none' && format('cc @{0}', steps.pr-check.outputs.author) || '' }}
           reviewers: ${{ steps.pr-check.outputs.merger }}

--- a/.github/workflows/update-docker-requirements.yml
+++ b/.github/workflows/update-docker-requirements.yml
@@ -28,6 +28,9 @@ jobs:
           python-version: "3.11"
           optional-dependencies: "false"
 
+      - name: Install GitHub CLI
+        run: sudo apt-get install gh
+
       - name: Update docker requirements
         id: update
         run: |
@@ -38,6 +41,14 @@ jobs:
 
           NEEDS_UPDATE=$(git diff --quiet && echo 'false' || echo 'true')
           echo "needs-update=${NEEDS_UPDATE}" | tee --append $GITHUB_OUTPUT
+
+      - name: Get last merged PR info
+        id: pr_info
+        run: |
+          LAST_MERGED_PR=$(gh pr list --repo $GITHUB_REPOSITORY --state closed --json number --jq '.[0].number')
+          PR_INFO=$(gh pr view $LAST_MERGED_PR --repo $GITHUB_REPOSITORY --json author,mergedBy --jq '{author: .author.login, mergedBy: .mergedBy.login}')
+          echo "pr_author=$(echo $PR_INFO | jq -r .author)" >> $GITHUB_ENV
+          echo "pr_mergedBy=$(echo $PR_INFO | jq -r .mergedBy)" >> $GITHUB_ENV
 
       - name: Open a PR to update the requirements
         # prettier-ignore
@@ -53,7 +64,7 @@ jobs:
           # prettier-ignore
           body:
             https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          reviewers: ${{ github.actor }}
+          reviewers: ${{ env.pr_author }},${{ env.pr_mergedBy }}
 
       - name: Show diff
         # prettier-ignore

--- a/.github/workflows/update-docker-requirements.yml
+++ b/.github/workflows/update-docker-requirements.yml
@@ -33,9 +33,6 @@ jobs:
           python-version: "3.11"
           optional-dependencies: "false"
 
-      - name: Install GitHub CLI
-        run: sudo apt-get install gh
-
       - name: Update docker requirements
         id: update
         run: |

--- a/.github/workflows/update-docker-requirements.yml
+++ b/.github/workflows/update-docker-requirements.yml
@@ -54,17 +54,20 @@ jobs:
             /repos/${{ github.repository }}/commits/${{ github.sha }}/pulls \
             --jq '.[0].number' || echo "none")
           if [ "${PR_NUMBER}" != "none" ]; then
-            HAS_PR='true'
             PR_INFO=$(gh pr view ${PR_NUMBER} --json author,mergedBy --jq '{author: .author.login, merger: .mergedBy.login}')
-            AUTHOR=$(echo ${PR_INFO} | jq -r .author)
-            MERGER=$(echo ${PR_INFO} | jq -r .merger)
+
+            if [ $? -eq 0 ]; then
+              AUTHOR=$(echo ${PR_INFO} | jq -r .author)
+              MERGER=$(echo ${PR_INFO} | jq -r .merger)
+            else
+              AUTHOR=${{ github.actor }}
+              MERGER="none"
+            fi
           else
-            HAS_PR='false'
             AUTHOR=${{ github.actor }}
             MERGER="none"
           fi
 
-          echo "has-pr=${HAS_PR}" | tee --append $GITHUB_OUTPUT
           echo "author=${AUTHOR}" | tee --append $GITHUB_OUTPUT
           echo "merger=${MERGER}" | tee --append $GITHUB_OUTPUT
 
@@ -80,4 +83,5 @@ jobs:
           body: |
             Automatic update of requirements-docker.lock.
             [Workflow run details](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            ${{ steps.pr-check.outputs['cc-author'] }}
           reviewers: ${{ steps.pr-check.outputs.merger }}

--- a/.github/workflows/update-docker-requirements.yml
+++ b/.github/workflows/update-docker-requirements.yml
@@ -32,6 +32,12 @@ jobs:
       - name: Install GitHub CLI
         run: sudo apt-get install gh
 
+      - name: Set up GitHub CLI authentication
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh auth login --with-token <<< $GH_TOKEN
+
       - name: Update docker requirements
         id: update
         run: |
@@ -45,6 +51,8 @@ jobs:
 
       - name: Get last merged PR info
         id: pr_info
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           LAST_MERGED_PR=$(gh pr list --repo $GITHUB_REPOSITORY --state closed --json number --jq '.[0].number')
           PR_INFO=$(gh pr view $LAST_MERGED_PR --repo $GITHUB_REPOSITORY --json author,mergedBy --jq '{author: .author.login, mergedBy: .mergedBy.login}')
@@ -52,9 +60,7 @@ jobs:
           echo "pr_mergedBy=$(echo $PR_INFO | jq -r .mergedBy)" >> $GITHUB_ENV
 
       - name: Open a PR to update the requirements
-        # prettier-ignore
-        if:
-          ${{ steps.update.outputs.needs-update && github.event_name == 'workflow_dispatch' }}
+        if: ${{ steps.update.outputs.needs-update }}
         uses: peter-evans/create-pull-request@v5
         with:
           commit-message: update requirements-docker.lock
@@ -68,7 +74,5 @@ jobs:
           reviewers: ${{ env.pr_author }},${{ env.pr_mergedBy }}
 
       - name: Show diff
-        # prettier-ignore
-        if:
-          ${{ steps.update.outputs.needs-update && github.event_name != 'workflow_dispatch' }}
+        if: ${{ steps.update.outputs.needs-update }}
         run: git diff --exit-code

--- a/.github/workflows/update-docker-requirements.yml
+++ b/.github/workflows/update-docker-requirements.yml
@@ -56,14 +56,8 @@ jobs:
             --jq '.[0].number')
           if [ $? -eq 0 ]; then
             PR_INFO=$(gh pr view ${PR_NUMBER} --json author,mergedBy --jq '{author: .author.login, merger: .mergedBy.login}')
-
-            if [ $? -eq 0 ]; then
-              AUTHOR=$(echo ${PR_INFO} | jq -r .author)
-              MERGER=$(echo ${PR_INFO} | jq -r .merger)
-            else
-              AUTHOR=${{ github.actor }}
-              MERGER="none"
-            fi
+            AUTHOR=$(echo ${PR_INFO} | jq -r .author)
+            MERGER=$(echo ${PR_INFO} | jq -r .merger)
           else
             AUTHOR=${{ github.actor }}
             MERGER="none"

--- a/.github/workflows/update-docker-requirements.yml
+++ b/.github/workflows/update-docker-requirements.yml
@@ -87,31 +87,10 @@ jobs:
             ${{ steps.pr-check.outputs.author != 'none' && format('cc @{0}', steps.pr-check.outputs.author) || '' }}
           reviewers: ${{ steps.pr-check.outputs.merger }}
 
-  notify-failure:
-    runs-on: ubuntu-latest
-    needs: update
-    if: failure()
-    steps:
       - name: Create failure issue
-        uses: actions/github-script@v6
+        if: failure()
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const issueTitle = 'Workflow Failure: docker-requirements';
-            const issueBody = `The workflow 'docker-requirements' has failed.
-            Please check the details at: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-            `;
-            const { data: issues } = await github.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open'
-            });
-            const existingIssue = issues.find(issue => issue.title === issueTitle);
-            if (!existingIssue) {
-              await github.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title: issueTitle,
-                body: issueBody
-              });
-            }
+          filename: .github/ISSUE_TEMPLATE/DOCKER_ISSUE_TEMPLATE.md


### PR DESCRIPTION
Should Fix #458 

This PR updates the Docker requirements workflow to:

- Automatically create PRs to update requirements-docker.lock when changes are detected.
- Dynamically request reviews from the author and the person who merged the last PR into main.


I've also tested this updated workflow a number of times on my fork to- 
- Here's the [test workflow run](https://github.com/arjxn-py/ragna/actions/runs/10049115488/job/27774541367#step:6:1)
- Here's [the automatically created PR](https://github.com/arjxn-py/ragna/pull/6) when I bumped down `panel==1.4.2` on my fork for testing.