### PR TITLE
fix streaming handling for builtin assistants

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -6,6 +6,9 @@ dependencies:
   - pip
   - git-lfs
   - pip:
+      - httpx_sse
+      - ijson
+      - sse_starlette
       - python-dotenv
       - pytest >=6
       - pytest-mock

--- a/ragna/_utils.py
+++ b/ragna/_utils.py
@@ -94,7 +94,7 @@ def timeout_after(
     seconds: float = 30, *, message: str = ""
 ) -> Callable[[Callable], Callable]:
     timeout = f"Timeout after {seconds:.1f} seconds"
-    message = f"{timeout}: {message}" if message else timeout
+    message = timeout if message else f"{timeout}: {message}"
 
     def decorator(fn: Callable) -> Callable:
         if is_debugging():

--- a/ragna/_utils.py
+++ b/ragna/_utils.py
@@ -94,7 +94,7 @@ def timeout_after(
     seconds: float = 30, *, message: str = ""
 ) -> Callable[[Callable], Callable]:
     timeout = f"Timeout after {seconds:.1f} seconds"
-    message = timeout if message else f"{timeout}: {message}"
+    message = f"{timeout}: {message}" if message else timeout
 
     def decorator(fn: Callable) -> Callable:
         if is_debugging():

--- a/ragna/assistants/_ai21labs.py
+++ b/ragna/assistants/_ai21labs.py
@@ -29,7 +29,7 @@ class Ai21LabsAssistant(HttpApiAssistant):
         # See https://docs.ai21.com/reference/j2-complete-api-ref#api-parameters
         # See https://docs.ai21.com/reference/j2-chat-api#understanding-the-response
         prompt, sources = (message := messages[-1]).content, message.sources
-        async for data in self._call_api(
+        async with self._call_api(
             "POST",
             f"https://api.ai21.com/studio/v1/j2-{self._MODEL_TYPE}/chat",
             headers={
@@ -49,8 +49,9 @@ class Ai21LabsAssistant(HttpApiAssistant):
                 ],
                 "system": self._make_system_content(sources),
             },
-        ):
-            yield cast(str, data["outputs"][0]["text"])
+        ) as stream:
+            async for data in stream:
+                yield cast(str, data["outputs"][0]["text"])
 
 
 # The Jurassic2Mid assistant receives a 500 internal service error from the remote

--- a/ragna/assistants/_ai21labs.py
+++ b/ragna/assistants/_ai21labs.py
@@ -29,7 +29,7 @@ class Ai21LabsAssistant(HttpApiAssistant):
         # See https://docs.ai21.com/reference/j2-complete-api-ref#api-parameters
         # See https://docs.ai21.com/reference/j2-chat-api#understanding-the-response
         prompt, sources = (message := messages[-1]).content, message.sources
-        async with self._call_api(
+        async for data in self._call_api(
             "POST",
             f"https://api.ai21.com/studio/v1/j2-{self._MODEL_TYPE}/chat",
             headers={
@@ -49,9 +49,8 @@ class Ai21LabsAssistant(HttpApiAssistant):
                 ],
                 "system": self._make_system_content(sources),
             },
-        ) as stream:
-            async for data in stream:
-                yield cast(str, data["outputs"][0]["text"])
+        ):
+            yield cast(str, data["outputs"][0]["text"])
 
 
 # The Jurassic2Mid assistant receives a 500 internal service error from the remote

--- a/ragna/assistants/_anthropic.py
+++ b/ragna/assistants/_anthropic.py
@@ -42,7 +42,7 @@ class AnthropicAssistant(HttpApiAssistant):
         # See https://docs.anthropic.com/claude/reference/messages_post
         # See https://docs.anthropic.com/claude/reference/streaming
         prompt, sources = (message := messages[-1]).content, message.sources
-        async with self._call_api(
+        async for data in self._call_api(
             "POST",
             "https://api.anthropic.com/v1/messages",
             headers={
@@ -59,17 +59,16 @@ class AnthropicAssistant(HttpApiAssistant):
                 "temperature": 0.0,
                 "stream": True,
             },
-        ) as stream:
-            async for data in stream:
-                # See https://docs.anthropic.com/claude/reference/messages-streaming#raw-http-stream-response
-                if "error" in data:
-                    raise RagnaException(data["error"].pop("message"), **data["error"])
-                elif data["type"] == "message_stop":
-                    break
-                elif data["type"] != "content_block_delta":
-                    continue
+        ):
+            # See https://docs.anthropic.com/claude/reference/messages-streaming#raw-http-stream-response
+            if "error" in data:
+                raise RagnaException(data["error"].pop("message"), **data["error"])
+            elif data["type"] == "message_stop":
+                break
+            elif data["type"] != "content_block_delta":
+                continue
 
-                yield cast(str, data["delta"].pop("text"))
+            yield cast(str, data["delta"].pop("text"))
 
 
 class ClaudeOpus(AnthropicAssistant):

--- a/ragna/assistants/_cohere.py
+++ b/ragna/assistants/_cohere.py
@@ -31,7 +31,7 @@ class CohereAssistant(HttpApiAssistant):
         # See https://docs.cohere.com/reference/chat
         # See https://docs.cohere.com/docs/retrieval-augmented-generation-rag
         prompt, sources = (message := messages[-1]).content, message.sources
-        async with self._call_api(
+        async for event in self._call_api(
             "POST",
             "https://api.cohere.ai/v1/chat",
             headers={
@@ -48,15 +48,14 @@ class CohereAssistant(HttpApiAssistant):
                 "max_tokens": max_new_tokens,
                 "documents": self._make_source_documents(sources),
             },
-        ) as stream:
-            async for event in stream:
-                if event["event_type"] == "stream-end":
-                    if event["event_type"] == "COMPLETE":
-                        break
+        ):
+            if event["event_type"] == "stream-end":
+                if event["event_type"] == "COMPLETE":
+                    break
 
-                    raise RagnaException(event["error_message"])
-                if "text" in event:
-                    yield cast(str, event["text"])
+                raise RagnaException(event["error_message"])
+            if "text" in event:
+                yield cast(str, event["text"])
 
 
 class Command(CohereAssistant):

--- a/ragna/assistants/_google.py
+++ b/ragna/assistants/_google.py
@@ -29,7 +29,7 @@ class GoogleAssistant(HttpApiAssistant):
         self, messages: list[Message], *, max_new_tokens: int = 256
     ) -> AsyncIterator[str]:
         prompt, sources = (message := messages[-1]).content, message.sources
-        async with self._call_api(
+        async for chunk in self._call_api(
             "POST",
             f"https://generativelanguage.googleapis.com/v1beta/models/{self._MODEL}:streamGenerateContent",
             params={"key": self._api_key},
@@ -58,9 +58,8 @@ class GoogleAssistant(HttpApiAssistant):
                 },
             },
             parse_kwargs=dict(item="item.candidates.item.content.parts.item.text"),
-        ) as stream:
-            async for chunk in stream:
-                yield chunk
+        ):
+            yield chunk
 
 
 class GeminiPro(GoogleAssistant):

--- a/ragna/assistants/_google.py
+++ b/ragna/assistants/_google.py
@@ -29,7 +29,7 @@ class GoogleAssistant(HttpApiAssistant):
         self, messages: list[Message], *, max_new_tokens: int = 256
     ) -> AsyncIterator[str]:
         prompt, sources = (message := messages[-1]).content, message.sources
-        async for chunk in self._call_api(
+        async with self._call_api(
             "POST",
             f"https://generativelanguage.googleapis.com/v1beta/models/{self._MODEL}:streamGenerateContent",
             params={"key": self._api_key},
@@ -58,8 +58,9 @@ class GoogleAssistant(HttpApiAssistant):
                 },
             },
             parse_kwargs=dict(item="item.candidates.item.content.parts.item.text"),
-        ):
-            yield chunk
+        ) as stream:
+            async for chunk in stream:
+                yield chunk
 
 
 class GeminiPro(GoogleAssistant):

--- a/ragna/assistants/_http_api.py
+++ b/ragna/assistants/_http_api.py
@@ -2,7 +2,7 @@ import contextlib
 import enum
 import json
 import os
-from typing import Any, AsyncContextManager, AsyncIterator, Optional
+from typing import Any, AsyncIterator, Optional
 
 import httpx
 
@@ -47,7 +47,7 @@ class HttpApiCaller:
         *,
         parse_kwargs: Optional[dict[str, Any]] = None,
         **kwargs: Any,
-    ) -> AsyncContextManager[AsyncIterator[Any]]:
+    ) -> AsyncIterator[Any]:
         if self._protocol is None:
             call_method = self._no_stream
         else:
@@ -56,10 +56,8 @@ class HttpApiCaller:
                 HttpStreamingProtocol.JSONL: self._stream_jsonl,
                 HttpStreamingProtocol.JSON: self._stream_json,
             }[self._protocol]
-
         return call_method(method, url, parse_kwargs=parse_kwargs or {}, **kwargs)
 
-    @contextlib.asynccontextmanager
     async def _no_stream(
         self,
         method: str,
@@ -70,13 +68,8 @@ class HttpApiCaller:
     ) -> AsyncIterator[Any]:
         response = await self._client.request(method, url, **kwargs)
         await self._assert_api_call_is_success(response)
+        yield response.json()
 
-        async def stream() -> AsyncIterator[Any]:
-            yield response.json()
-
-        yield stream()
-
-    @contextlib.asynccontextmanager
     async def _stream_sse(
         self,
         method: str,
@@ -92,13 +85,9 @@ class HttpApiCaller:
         ) as event_source:
             await self._assert_api_call_is_success(event_source.response)
 
-            async def stream() -> AsyncIterator[Any]:
-                async for sse in event_source.aiter_sse():
-                    yield json.loads(sse.data)
+            async for sse in event_source.aiter_sse():
+                yield json.loads(sse.data)
 
-            yield stream()
-
-    @contextlib.asynccontextmanager
     async def _stream_jsonl(
         self,
         method: str,
@@ -110,11 +99,8 @@ class HttpApiCaller:
         async with self._client.stream(method, url, **kwargs) as response:
             await self._assert_api_call_is_success(response)
 
-            async def stream() -> AsyncIterator[Any]:
-                async for chunk in response.aiter_lines():
-                    yield json.loads(chunk)
-
-            yield stream()
+            async for chunk in response.aiter_lines():
+                yield json.loads(chunk)
 
     # ijson does not support reading from an (async) iterator, but only from file-like
     # objects, i.e. https://docs.python.org/3/tutorial/inputoutput.html#methods-of-file-objects.
@@ -134,7 +120,6 @@ class HttpApiCaller:
                 return b""
             return await anext(self._ait, b"")  # type: ignore[call-arg]
 
-    @contextlib.asynccontextmanager
     async def _stream_json(
         self,
         method: str,
@@ -151,13 +136,10 @@ class HttpApiCaller:
         async with self._client.stream(method, url, **kwargs) as response:
             await self._assert_api_call_is_success(response)
 
-            async def stream() -> AsyncIterator[Any]:
-                async for chunk in ijson.items(
-                    self._AsyncIteratorReader(response.aiter_bytes(chunk_size)), item
-                ):
-                    yield chunk
-
-            yield stream()
+            async for chunk in ijson.items(
+                self._AsyncIteratorReader(response.aiter_bytes(chunk_size)), item
+            ):
+                yield chunk
 
     async def _assert_api_call_is_success(self, response: httpx.Response) -> None:
         if response.is_success:

--- a/ragna/assistants/_ollama.py
+++ b/ragna/assistants/_ollama.py
@@ -33,16 +33,13 @@ class OllamaAssistant(OpenaiLikeHttpApiAssistant):
         self, messages: list[Message], *, max_new_tokens: int = 256
     ) -> AsyncIterator[str]:
         prompt, sources = (message := messages[-1]).content, message.sources
-        async with self._call_openai_api(
-            prompt, sources, max_new_tokens=max_new_tokens
-        ) as stream:
-            async for data in stream:
-                # Modeled after
-                # https://github.com/ollama/ollama/blob/06a1508bfe456e82ba053ea554264e140c5057b5/examples/python-loganalysis/readme.md?plain=1#L57-L62
-                if "error" in data:
-                    raise RagnaException(data["error"])
-                if not data["done"]:
-                    yield cast(str, data["message"]["content"])
+        async for data in self._stream(prompt, sources, max_new_tokens=max_new_tokens):
+            # Modeled after
+            # https://github.com/ollama/ollama/blob/06a1508bfe456e82ba053ea554264e140c5057b5/examples/python-loganalysis/readme.md?plain=1#L57-L62
+            if "error" in data:
+                raise RagnaException(data["error"])
+            if not data["done"]:
+                yield cast(str, data["message"]["content"])
 
 
 class OllamaGemma2B(OllamaAssistant):

--- a/ragna/assistants/_ollama.py
+++ b/ragna/assistants/_ollama.py
@@ -33,13 +33,16 @@ class OllamaAssistant(OpenaiLikeHttpApiAssistant):
         self, messages: list[Message], *, max_new_tokens: int = 256
     ) -> AsyncIterator[str]:
         prompt, sources = (message := messages[-1]).content, message.sources
-        async for data in self._stream(prompt, sources, max_new_tokens=max_new_tokens):
-            # Modeled after
-            # https://github.com/ollama/ollama/blob/06a1508bfe456e82ba053ea554264e140c5057b5/examples/python-loganalysis/readme.md?plain=1#L57-L62
-            if "error" in data:
-                raise RagnaException(data["error"])
-            if not data["done"]:
-                yield cast(str, data["message"]["content"])
+        async with self._call_openai_api(
+            prompt, sources, max_new_tokens=max_new_tokens
+        ) as stream:
+            async for data in stream:
+                # Modeled after
+                # https://github.com/ollama/ollama/blob/06a1508bfe456e82ba053ea554264e140c5057b5/examples/python-loganalysis/readme.md?plain=1#L57-L62
+                if "error" in data:
+                    raise RagnaException(data["error"])
+                if not data["done"]:
+                    yield cast(str, data["message"]["content"])
 
 
 class OllamaGemma2B(OllamaAssistant):

--- a/ragna/assistants/_openai.py
+++ b/ragna/assistants/_openai.py
@@ -1,6 +1,6 @@
 import abc
 from functools import cached_property
-from typing import Any, AsyncIterator, Optional, cast
+from typing import Any, AsyncContextManager, AsyncIterator, Optional, cast
 
 from ragna.core import Message, Source
 
@@ -23,9 +23,9 @@ class OpenaiLikeHttpApiAssistant(HttpApiAssistant):
         )
         return instruction + "\n\n".join(source.content for source in sources)
 
-    def _stream(
+    def _call_openai_api(
         self, prompt: str, sources: list[Source], *, max_new_tokens: int
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncContextManager[AsyncIterator[dict[str, Any]]]:
         # See https://platform.openai.com/docs/api-reference/chat/create
         # and https://platform.openai.com/docs/api-reference/chat/streaming
         headers = {
@@ -58,12 +58,15 @@ class OpenaiLikeHttpApiAssistant(HttpApiAssistant):
         self, messages: list[Message], *, max_new_tokens: int = 256
     ) -> AsyncIterator[str]:
         prompt, sources = (message := messages[-1]).content, message.sources
-        async for data in self._stream(prompt, sources, max_new_tokens=max_new_tokens):
-            choice = data["choices"][0]
-            if choice["finish_reason"] is not None:
-                break
+        async with self._call_openai_api(
+            prompt, sources, max_new_tokens=max_new_tokens
+        ) as stream:
+            async for data in stream:
+                choice = data["choices"][0]
+                if choice["finish_reason"] is not None:
+                    break
 
-            yield cast(str, choice["delta"]["content"])
+                yield cast(str, choice["delta"]["content"])
 
 
 class OpenaiAssistant(OpenaiLikeHttpApiAssistant):

--- a/tests/assistants/streaming_server.py
+++ b/tests/assistants/streaming_server.py
@@ -1,0 +1,49 @@
+import json
+import random
+
+import sse_starlette
+from fastapi import FastAPI, Request, Response, status
+from fastapi.responses import StreamingResponse
+
+app = FastAPI()
+
+
+@app.get("/health")
+async def health():
+    return Response(b"", status_code=status.HTTP_200_OK)
+
+
+@app.post("/sse")
+async def sse(request: Request):
+    data = await request.json()
+
+    async def stream():
+        for obj in data:
+            yield sse_starlette.ServerSentEvent(json.dumps(obj))
+
+    return sse_starlette.EventSourceResponse(stream())
+
+
+@app.post("/jsonl")
+async def jsonl(request: Request):
+    data = await request.json()
+
+    async def stream():
+        for obj in data:
+            yield f"{json.dumps(obj)}\n"
+
+    return StreamingResponse(stream())
+
+
+@app.post("/json")
+async def json_(request: Request):
+    data = await request.body()
+
+    async def stream():
+        start = 0
+        while start < len(data):
+            end = start + random.randint(1, 10)
+            yield data[start:end]
+            start = end
+
+    return StreamingResponse(stream())

--- a/tests/assistants/test_api.py
+++ b/tests/assistants/test_api.py
@@ -1,12 +1,19 @@
+import asyncio
+import itertools
+import json
 import os
+import time
+from pathlib import Path
 
+import httpx
 import pytest
 
 from ragna import assistants
 from ragna._compat import anext
-from ragna.assistants._http_api import HttpApiAssistant
+from ragna._utils import timeout_after
+from ragna.assistants._http_api import HttpApiAssistant, HttpStreamingProtocol
 from ragna.core import Message, RagnaException
-from tests.utils import skip_on_windows
+from tests.utils import background_subprocess, get_available_port, skip_on_windows
 
 HTTP_API_ASSISTANTS = [
     assistant
@@ -30,3 +37,113 @@ async def test_api_call_error_smoke(mocker, assistant):
 
     with pytest.raises(RagnaException, match="API call failed"):
         await anext(chunks)
+
+
+@pytest.fixture
+def streaming_server():
+    port = get_available_port()
+    base_url = f"http://localhost:{port}"
+
+    with background_subprocess(
+        "uvicorn",
+        f"--app-dir={Path(__file__).parent}",
+        f"--port={port}",
+        "streaming_server:app",
+    ):
+
+        def up():
+            try:
+                return httpx.get(f"{base_url}/health").is_success
+            except httpx.ConnectError:
+                return False
+
+        @timeout_after(10, message="Streaming server failed to start")
+        def wait():
+            while not up():
+                time.sleep(0.2)
+
+        wait()
+
+        yield base_url
+
+
+@pytest.mark.parametrize("streaming_protocol", list(HttpStreamingProtocol))
+async def test_http_streaming(streaming_server, streaming_protocol):
+    class HttpStreamingAssistant(HttpApiAssistant):
+        _STREAMING_PROTOCOL = streaming_protocol
+        _API_KEY_ENV_VAR = None
+
+        async def answer(self, messages):
+            if streaming_protocol is HttpStreamingProtocol.JSON:
+                parse_kwargs = dict(item="item")
+            else:
+                parse_kwargs = dict()
+
+            async with self._call_api(
+                "POST",
+                f"{streaming_server}/{streaming_protocol.name.lower()}",
+                content=messages[-1].content,
+                parse_kwargs=parse_kwargs,
+            ) as stream:
+                async for chunk in stream:
+                    yield chunk
+
+    assistant = HttpStreamingAssistant()
+
+    expected = [{"chunk": chunk} for chunk in ["foo", "bar", "baz"]]
+    expected_chunks = iter(expected)
+    actual_chunks = assistant.answer([Message(content=json.dumps(expected))])
+    async for actual_chunk in actual_chunks:
+        expected_chunk = next(expected_chunks)
+        assert actual_chunk == expected_chunk
+
+    with pytest.raises(StopIteration):
+        next(expected_chunks)
+
+
+@pytest.mark.parametrize("streaming_protocol", list(HttpStreamingProtocol))
+def test_http_streaming_termination(streaming_server, streaming_protocol):
+    # Non-regression test for https://github.com/Quansight/ragna/pull/462
+
+    class HttpStreamingAssistant(HttpApiAssistant):
+        _STREAMING_PROTOCOL = streaming_protocol
+        _API_KEY_ENV_VAR = None
+
+        async def answer(self, messages):
+            if streaming_protocol is HttpStreamingProtocol.JSON:
+                parse_kwargs = dict(item="item")
+            else:
+                parse_kwargs = dict()
+
+            async with self._call_api(
+                "POST",
+                f"{streaming_server}/{streaming_protocol.name.lower()}",
+                content=messages[-1].content,
+                parse_kwargs=parse_kwargs,
+            ) as stream:
+                async for chunk in stream:
+                    if chunk["break"]:
+                        break
+
+                    yield chunk
+
+    async def main():
+        assistant = HttpStreamingAssistant()
+
+        expected = [
+            {"chunk": "foo", "break": False},
+            {"chunk": "bar", "break": False},
+            {"chunk": "baz", "break": True},
+        ]
+        expected_chunks = itertools.takewhile(
+            lambda chunk: not chunk["break"], expected
+        )
+        actual_chunks = assistant.answer([Message(content=json.dumps(expected))])
+        async for actual_chunk in actual_chunks:
+            expected_chunk = next(expected_chunks)
+            assert actual_chunk == expected_chunk
+
+        with pytest.raises(StopIteration):
+            next(expected_chunks)
+
+    asyncio.run(main())

--- a/tests/assistants/test_api.py
+++ b/tests/assistants/test_api.py
@@ -89,16 +89,17 @@ class HttpStreamingAssistant(HttpApiAssistant):
         else:
             parse_kwargs = dict()
 
-        async for chunk in self._call_api(
+        async with self._call_api(
             "POST",
             self._endpoint,
             content=messages[-1].content,
             parse_kwargs=parse_kwargs,
-        ):
-            if chunk.get("break"):
-                break
+        ) as stream:
+            async for chunk in stream:
+                if chunk.get("break"):
+                    break
 
-            yield chunk
+                yield chunk
 
 
 @pytest.mark.parametrize("streaming_protocol", list(HttpStreamingProtocol))

--- a/tests/assistants/test_api.py
+++ b/tests/assistants/test_api.py
@@ -106,9 +106,9 @@ class HttpStreamingAssistant(HttpApiAssistant):
 async def test_http_streaming(streaming_server, streaming_protocol):
     assistant = HttpStreamingAssistant.new(streaming_server, streaming_protocol)
 
-    expected = [{"chunk": chunk} for chunk in ["foo", "bar", "baz"]]
-    expected_chunks = iter(expected)
-    actual_chunks = assistant.answer([Message(content=json.dumps(expected))])
+    data = [{"chunk": chunk} for chunk in ["foo", "bar", "baz"]]
+    expected_chunks = iter(data)
+    actual_chunks = assistant.answer([Message(content=json.dumps(data))])
     async for actual_chunk in actual_chunks:
         expected_chunk = next(expected_chunks)
         assert actual_chunk == expected_chunk
@@ -124,15 +124,13 @@ def test_http_streaming_termination(streaming_server, streaming_protocol):
     async def main():
         assistant = HttpStreamingAssistant.new(streaming_server, streaming_protocol)
 
-        expected = [
+        data = [
             {"chunk": "foo", "break": False},
             {"chunk": "bar", "break": False},
             {"chunk": "baz", "break": True},
         ]
-        expected_chunks = itertools.takewhile(
-            lambda chunk: not chunk["break"], expected
-        )
-        actual_chunks = assistant.answer([Message(content=json.dumps(expected))])
+        expected_chunks = itertools.takewhile(lambda chunk: not chunk["break"], data)
+        actual_chunks = assistant.answer([Message(content=json.dumps(data))])
         async for actual_chunk in actual_chunks:
             expected_chunk = next(expected_chunks)
             assert actual_chunk == expected_chunk

--- a/tests/assistants/test_api.py
+++ b/tests/assistants/test_api.py
@@ -102,6 +102,7 @@ class HttpStreamingAssistant(HttpApiAssistant):
                 yield chunk
 
 
+@skip_on_windows
 @pytest.mark.parametrize("streaming_protocol", list(HttpStreamingProtocol))
 async def test_http_streaming(streaming_server, streaming_protocol):
     assistant = HttpStreamingAssistant.new(streaming_server, streaming_protocol)
@@ -117,6 +118,7 @@ async def test_http_streaming(streaming_server, streaming_protocol):
         next(expected_chunks)
 
 
+@skip_on_windows
 @pytest.mark.parametrize("streaming_protocol", list(HttpStreamingProtocol))
 def test_http_streaming_termination(streaming_server, streaming_protocol):
     # Non-regression test for https://github.com/Quansight/ragna/pull/462

--- a/tests/assistants/test_api.py
+++ b/tests/assistants/test_api.py
@@ -57,7 +57,7 @@ def streaming_server():
             except httpx.ConnectError:
                 return False
 
-        @timeout_after(10, message="Streaming server failed to start")
+        @timeout_after(10, message="Failed to start streaming server")
         def wait():
             while not up():
                 time.sleep(0.2)

--- a/tests/assistants/test_api.py
+++ b/tests/assistants/test_api.py
@@ -89,17 +89,16 @@ class HttpStreamingAssistant(HttpApiAssistant):
         else:
             parse_kwargs = dict()
 
-        async with self._call_api(
+        async for chunk in self._call_api(
             "POST",
             self._endpoint,
             content=messages[-1].content,
             parse_kwargs=parse_kwargs,
-        ) as stream:
-            async for chunk in stream:
-                if chunk.get("break"):
-                    break
+        ):
+            if chunk.get("break"):
+                break
 
-                yield chunk
+            yield chunk
 
 
 @pytest.mark.parametrize("streaming_protocol", list(HttpStreamingProtocol))

--- a/tests/deploy/ui/test_ui.py
+++ b/tests/deploy/ui/test_ui.py
@@ -1,4 +1,3 @@
-import socket
 import subprocess
 import sys
 import time
@@ -11,12 +10,7 @@ from playwright.sync_api import Page, expect
 from ragna._utils import timeout_after
 from ragna.deploy import Config
 from tests.deploy.utils import TestAssistant
-
-
-def get_available_port():
-    with socket.socket() as s:
-        s.bind(("", 0))
-        return s.getsockname()[1]
+from tests.utils import get_available_port
 
 
 @pytest.fixture

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,27 @@
+import contextlib
 import platform
+import socket
+import subprocess
+import sys
 
 import pytest
 
 skip_on_windows = pytest.mark.skipif(
     platform.system() == "Windows", reason="Test is broken skipped on Windows"
 )
+
+
+@contextlib.contextmanager
+def background_subprocess(*args, stdout=sys.stdout, stderr=sys.stdout, **kwargs):
+    process = subprocess.Popen(args, stdout=stdout, stderr=stderr, **kwargs)
+    try:
+        yield process
+    finally:
+        process.kill()
+        process.communicate()
+
+
+def get_available_port():
+    with socket.socket() as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]


### PR DESCRIPTION
My patch in #425 is broken when using the Python API with `asyncio.run`, i.e. the regular use case. As implemented in #425, `break`ing out of the loop in `.answer()` means that the async iterator is not fully exhausted, i.e. `AsyncStopIteration` is never raised. This leads to the context manager that handles the HTTP request staying open longer than `Chat.answer`. When it is cleaned up eventually, internally it calls `await request.aclose()`. However, if at that point the async event loop is already killed, e.g. because the coroutine called by `asyncio.run` is finished, you'll get an error:

```
Task exception was never retrieved
future: <Task finished name='Task-5' coro=<<async_generator_athrow without __name__>()> exception=RuntimeError('aclose(): asynchronous generator is already running')>
RuntimeError: aclose(): asynchronous generator is already running
Exception ignored in: <coroutine object Response.aclose at 0x73f95efdfcc0>
Traceback (most recent call last):
  File "/home/philip/.conda/envs/ragna-deploy-dev/lib/python3.9/site-packages/httpx/_models.py", line 1008, in aclose
    await self.stream.aclose()
  File "/home/philip/.conda/envs/ragna-deploy-dev/lib/python3.9/site-packages/httpx/_client.py", line 155, in aclose
    await self._stream.aclose()
  File "/home/philip/.conda/envs/ragna-deploy-dev/lib/python3.9/site-packages/httpx/_transports/default.py", line 259, in aclose
    await self._httpcore_stream.aclose()
  File "/home/philip/.conda/envs/ragna-deploy-dev/lib/python3.9/site-packages/httpcore/_async/connection_pool.py", line 374, in aclose
    await self._stream.aclose()
  File "/home/philip/.conda/envs/ragna-deploy-dev/lib/python3.9/site-packages/httpcore/_synchronization.py", line 225, in __exit__
    self._anyio_shield.__exit__(exc_type, exc_value, traceback)
  File "/home/philip/.conda/envs/ragna-deploy-dev/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 406, in __exit__
    if current_task() is not self._host_task:
  File "/home/philip/.conda/envs/ragna-deploy-dev/lib/python3.9/asyncio/tasks.py", line 38, in current_task
    loop = events.get_running_loop()
RuntimeError: no running event loop
```

To fix this, this PR introduces the same pattern for our streaming handling that `httpx` and `httpx_sse` use as well: a context manager creates the stream and the stream can than be iterated on. 

https://github.com/Quansight/ragna/blob/7c5728af3673868222ded6f06bb02f6f6d9cf03a/ragna/assistants/_http_api.py#L83-L89

https://github.com/Quansight/ragna/blob/7c5728af3673868222ded6f06bb02f6f6d9cf03a/ragna/assistants/_http_api.py#L99-L103

Basically, we switch from

```python
async for data in self._call_api(...):
    ...
```

to

```python
async with self._call_api(...) as stream:
    async for data in stream:
        ...
```

With this pattern, the cleanup is correctly handled when we exit `.answer()` and thus get rid of the error.