### PR TITLE
support pydantic (de)serialization on MetadataFilter

### DIFF
--- a/tests/core/test_metadata_filter.py
+++ b/tests/core/test_metadata_filter.py
@@ -1,3 +1,4 @@
+import pydantic
 import pytest
 
 from ragna.core import MetadataFilter, MetadataOperator
@@ -70,8 +71,28 @@ def test_self_similarity(metadata_filter):
 
 
 @metadata_filters
-def test_json_roundtrip(metadata_filter):
-    assert MetadataFilter.from_json(metadata_filter.to_json()) == metadata_filter
+def test_primitive_roundtrip(metadata_filter):
+    assert (
+        MetadataFilter.from_primitive(metadata_filter.to_primitive()) == metadata_filter
+    )
+
+
+@metadata_filters
+def test_pydantic(metadata_filter):
+    class Model(pydantic.BaseModel):
+        mf: MetadataFilter
+
+    assert Model(mf=metadata_filter).mf == metadata_filter
+    assert Model(mf=metadata_filter.to_primitive()).mf == metadata_filter
+    assert Model(mf=metadata_filter).model_dump(mode="json") == {
+        "mf": metadata_filter.to_primitive()
+    }
+
+
+@metadata_filters
+def test_pydantic_deserialize(metadata_filter):
+    class Model(pydantic.BaseModel):
+        metadata_filter: MetadataFilter
 
 
 @metadata_filters

--- a/tests/core/test_metadata_filter.py
+++ b/tests/core/test_metadata_filter.py
@@ -71,7 +71,7 @@ def test_self_similarity(metadata_filter):
 
 
 @metadata_filters
-def test_primitive_roundtrip(metadata_filter):
+def test_to_from_primitive_roundtrip(metadata_filter):
     assert (
         MetadataFilter.from_primitive(metadata_filter.to_primitive()) == metadata_filter
     )
@@ -87,12 +87,6 @@ def test_pydantic(metadata_filter):
     assert Model(mf=metadata_filter).model_dump(mode="json") == {
         "mf": metadata_filter.to_primitive()
     }
-
-
-@metadata_filters
-def test_pydantic_deserialize(metadata_filter):
-    class Model(pydantic.BaseModel):
-        metadata_filter: MetadataFilter
 
 
 @metadata_filters


### PR DESCRIPTION
The is a prerequisite for using `MetadataFilter` as part of FastAPI. I've scrapped the actual JSON serialization, because that would create JSON inside JSON with pydantic and pydantic knows how to serialize dicts anyway.