### PR TITLE
488 corpus cli

### DIFF
--- a/ragna/deploy/_cli/core.py
+++ b/ragna/deploy/_cli/core.py
@@ -1,3 +1,4 @@
+import json
 import subprocess
 import sys
 import time
@@ -8,10 +9,13 @@ import httpx
 import rich
 import typer
 import uvicorn
+from rich.progress import BarColumn, Progress, TextColumn, TimeRemainingColumn
 
 import ragna
 from ragna._utils import timeout_after
+from ragna.core._utils import default_user
 from ragna.deploy._api import app as api_app
+from ragna.deploy._api import database, orm
 from ragna.deploy._ui import app as ui_app
 
 from .config import ConfigOption, check_config, init_config
@@ -23,6 +27,8 @@ app = typer.Typer(
     add_completion=False,
     pretty_exceptions_enable=False,
 )
+corpus_app = typer.Typer()
+app.add_typer(corpus_app, name="corpus")
 
 
 def version_callback(value: bool) -> None:
@@ -171,3 +177,157 @@ def ui(
         if process is not None:
             process.kill()
             process.communicate()
+
+
+@corpus_app.command(help="Ingest some documents into a given corpus.")
+def ingest(
+    documents: list[Path],
+    corpus_name: Optional[str] = typer.Option(
+        None, help="Name of the corpus to ingest the documents into."
+    ),
+    config: ConfigOption = "./ragna.toml",  # type: ignore[assignment]
+    user: Optional[str] = typer.Option(
+        None, help="User to link the documents to in the ragna database."
+    ),
+    verbose: bool = typer.Option(
+        False, help="Print the documents that could not be ingested."
+    ),
+    ignore_log: bool = typer.Option(
+        False, help="Ignore the log file and re-ingest all documents."
+    ),
+) -> None:
+    try:
+        document_factory = getattr(config.document, "from_path")
+    except AttributeError:
+        raise typer.BadParameter(
+            f"{config.document.__name__} does not support creating documents from a path. "
+            "Please implement a `from_path` method."
+        )
+
+    try:
+        make_session = database.get_sessionmaker(config.api.database_url)
+    except Exception:
+        raise typer.BadParameter(
+            f"Could not connect to the database: {config.api.database_url}"
+        )
+
+    if user is None:
+        user = default_user()
+    with make_session() as session:
+        user_id = database._get_user_id(session, user)
+
+    # Log (JSONL) for recording which files previously added to vector database.
+    # Each entry has keys for 'user', 'corpus_name', 'source_storage' and 'document'.
+    ingestion_log = {}
+    if not ignore_log:
+        ingestion_log_file = Path.cwd() / ".ragna_ingestion_log.jsonl"
+        if ingestion_log_file.exists():
+            with open(ingestion_log_file, "r") as stream:
+                for line in stream:
+                    entry = json.loads(line)
+                    if entry["corpus_name"] == corpus_name and entry["user"] == user:
+                        ingestion_log.setdefault(entry["source_storage"], set()).add(
+                            entry["document"]
+                        )
+
+    with Progress(
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        "[progress.percentage]{task.percentage:>3.1f}%",
+        TimeRemainingColumn(),
+    ) as progress:
+        overall_task = progress.add_task(
+            "[cyan]Adding document embeddings to source storages...",
+            total=len(config.source_storages),
+        )
+
+        bad_documents_collection = {}
+        for source_storage in config.source_storages:
+            BATCH_SIZE = 10
+            number_of_batches = len(documents) // BATCH_SIZE
+            source_storage_task = progress.add_task(
+                f"[green]Adding document embeddings to {source_storage.__name__}...",
+                total=number_of_batches,
+            )
+
+            documents_not_ingested = []
+            for batch_number in range(0, len(documents), BATCH_SIZE):
+                document_instances = []
+                orm_documents = []
+
+                if source_storage.__name__ in ingestion_log:
+                    batch_doc_set = set(
+                        [
+                            str(doc)
+                            for doc in documents[
+                                batch_number : batch_number + BATCH_SIZE
+                            ]
+                        ]
+                    )
+                    if batch_doc_set.issubset(ingestion_log[source_storage.__name__]):
+                        progress.advance(source_storage_task)
+                        continue
+
+                for document in documents[batch_number : batch_number + BATCH_SIZE]:
+                    try:
+                        doc_instance = document_factory(document)
+                        document_instances.append(doc_instance)
+                        orm_documents.append(
+                            orm.Document(
+                                id=doc_instance.id,
+                                user_id=user_id,
+                                name=doc_instance.name,
+                                metadata_=doc_instance.metadata,
+                            )
+                        )
+                    except Exception:
+                        documents_not_ingested.append(document)
+
+                if not orm_documents:
+                    continue
+
+                try:
+                    session = make_session()
+                    session.add_all(orm_documents)
+                    source_storage().store(corpus_name, document_instances)
+                except Exception:
+                    documents_not_ingested.extend(
+                        documents[batch_number : batch_number + BATCH_SIZE]
+                    )
+                    session.rollback()
+                finally:
+                    session.commit()
+                    session.close()
+
+                if not ignore_log:
+                    with open(ingestion_log_file, "a") as stream:
+                        for document in documents[
+                            batch_number : batch_number + BATCH_SIZE
+                        ]:
+                            stream.write(
+                                json.dumps(
+                                    {
+                                        "user": user,
+                                        "corpus_name": corpus_name,
+                                        "source_storage": source_storage.__name__,
+                                        "document": str(document),
+                                    }
+                                )
+                                + "\n"
+                            )
+
+                progress.advance(source_storage_task)
+
+            bad_documents_collection[source_storage.__name__] = set(
+                documents_not_ingested
+            )
+
+            progress.update(source_storage_task, completed=number_of_batches)
+            progress.advance(overall_task)
+
+        progress.update(overall_task, completed=len(config.source_storages))
+
+        if verbose:
+            typer.echo(
+                f"Failed to embed the following documents: {bad_documents_collection}"
+            )

--- a/ragna/deploy/_cli/core.py
+++ b/ragna/deploy/_cli/core.py
@@ -1,4 +1,3 @@
-import json
 import signal
 import subprocess
 import sys
@@ -10,17 +9,14 @@ import httpx
 import rich
 import typer
 import uvicorn
-from rich.console import Console
-from rich.progress import BarColumn, Progress, TextColumn, TimeRemainingColumn
 
 import ragna
 from ragna._utils import timeout_after
-from ragna.core._utils import default_user
 from ragna.deploy._api import app as api_app
-from ragna.deploy._api import database, orm
 from ragna.deploy._ui import app as ui_app
 
 from .config import ConfigOption, check_config, init_config
+from .corpus import app as corpus_app
 
 app = typer.Typer(
     name="ragna",
@@ -29,8 +25,7 @@ app = typer.Typer(
     add_completion=False,
     pretty_exceptions_enable=False,
 )
-corpus_app = typer.Typer()
-app.add_typer(corpus_app, name="corpus")
+app.add_typer(corpus_app)
 
 
 def version_callback(value: bool) -> None:
@@ -188,175 +183,3 @@ def ui(
         ui_app(config=config, open_browser=open_browser).serve()  # type: ignore[no-untyped-call]
     finally:
         shutdown_api()
-
-
-@corpus_app.command(help="Ingest some documents into a given corpus.")
-def ingest(
-    documents: list[Path],
-    metadata_fields: Optional[Path] = typer.Option(
-        None,
-        help="JSON file that contains mappings from document name "
-        "to metadata fields associated with a document.",
-    ),
-    corpus_name: Optional[str] = typer.Option(
-        None, help="Name of the corpus to ingest the documents into."
-    ),
-    config: ConfigOption = "./ragna.toml",  # type: ignore[assignment]
-    user: Optional[str] = typer.Option(
-        None, help="User to link the documents to in the ragna database."
-    ),
-    report_failures: bool = typer.Option(
-        False, help="Output to STDERR the documents that failed to be ingested."
-    ),
-    ignore_log: bool = typer.Option(
-        False, help="Ignore the log file and re-ingest all documents."
-    ),
-) -> None:
-    try:
-        document_factory = getattr(config.document, "from_path")
-    except AttributeError:
-        raise typer.BadParameter(
-            f"{config.document.__name__} does not support creating documents from a path. "
-            "Please implement a `from_path` method."
-        )
-
-    try:
-        make_session = database.get_sessionmaker(config.api.database_url)
-    except Exception:
-        raise typer.BadParameter(
-            f"Could not connect to the database: {config.api.database_url}"
-        )
-
-    if metadata_fields:
-        try:
-            with open(metadata_fields, "r") as f:
-                metadata = json.load(f)
-        except Exception:
-            raise typer.BadParameter(
-                f"Could not read the metadata fields file: {metadata_fields}"
-            )
-    else:
-        metadata = {}
-
-    if user is None:
-        user = default_user()
-    with make_session() as session:  # type: ignore[attr-defined]
-        user_id = database._get_user_id(session, user)
-
-    # Log (JSONL) for recording which files previously added to vector database.
-    # Each entry has keys for 'user', 'corpus_name', 'source_storage' and 'document'.
-    ingestion_log: dict[str, set[str]] = {}
-    if not ignore_log:
-        ingestion_log_file = Path.cwd() / ".ragna_ingestion_log.jsonl"
-        if ingestion_log_file.exists():
-            with open(ingestion_log_file, "r") as stream:
-                for line in stream:
-                    entry = json.loads(line)
-                    if entry["corpus_name"] == corpus_name and entry["user"] == user:
-                        ingestion_log.setdefault(entry["source_storage"], set()).add(
-                            entry["document"]
-                        )
-
-    with Progress(
-        TextColumn("[progress.description]{task.description}"),
-        BarColumn(),
-        "[progress.percentage]{task.percentage:>3.1f}%",
-        TimeRemainingColumn(),
-    ) as progress:
-        overall_task = progress.add_task(
-            "[cyan]Adding document embeddings to source storages...",
-            total=len(config.source_storages),
-        )
-
-        for source_storage in config.source_storages:
-            BATCH_SIZE = 10
-            number_of_batches = len(documents) // BATCH_SIZE
-            source_storage_task = progress.add_task(
-                f"[green]Adding document embeddings to {source_storage.__name__}...",
-                total=number_of_batches,
-            )
-
-            for batch_number in range(0, len(documents), BATCH_SIZE):
-                documents_not_ingested = []
-                document_instances = []
-                orm_documents = []
-
-                if source_storage.__name__ in ingestion_log:
-                    batch_doc_set = set(
-                        [
-                            str(doc)
-                            for doc in documents[
-                                batch_number : batch_number + BATCH_SIZE
-                            ]
-                        ]
-                    )
-                    if batch_doc_set.issubset(ingestion_log[source_storage.__name__]):
-                        progress.advance(source_storage_task)
-                        continue
-
-                for document in documents[batch_number : batch_number + BATCH_SIZE]:
-                    try:
-                        doc_instance = document_factory(
-                            document,
-                            metadata=(
-                                metadata[str(document)]
-                                if str(document) in metadata
-                                else None
-                            ),
-                        )
-                        document_instances.append(doc_instance)
-                        orm_documents.append(
-                            orm.Document(
-                                id=doc_instance.id,
-                                user_id=user_id,
-                                name=doc_instance.name,
-                                metadata_=doc_instance.metadata,
-                            )
-                        )
-                    except Exception:
-                        documents_not_ingested.append(document)
-
-                if not orm_documents:
-                    continue
-
-                try:
-                    session = make_session()
-                    session.add_all(orm_documents)
-                    source_storage().store(corpus_name, document_instances)
-                    session.commit()
-                except Exception:
-                    documents_not_ingested.extend(
-                        documents[batch_number : batch_number + BATCH_SIZE]
-                    )
-                    session.rollback()
-                finally:
-                    session.close()
-
-                if not ignore_log:
-                    with open(ingestion_log_file, "a") as stream:
-                        for document in documents[
-                            batch_number : batch_number + BATCH_SIZE
-                        ]:
-                            stream.write(
-                                json.dumps(
-                                    {
-                                        "user": user,
-                                        "corpus_name": corpus_name,
-                                        "source_storage": source_storage.__name__,
-                                        "document": str(document),
-                                    }
-                                )
-                                + "\n"
-                            )
-
-                if report_failures:
-                    Console(file=sys.stderr).print(
-                        f"{source_storage.__name__} failed to embed:\n{documents_not_ingested}",
-                    )
-
-                progress.advance(source_storage_task)
-
-            progress.update(source_storage_task, completed=number_of_batches)
-            progress.advance(overall_task)
-
-        progress.update(overall_task, completed=len(config.source_storages))

--- a/ragna/deploy/_cli/core.py
+++ b/ragna/deploy/_cli/core.py
@@ -290,13 +290,13 @@ def ingest(
                     session = make_session()
                     session.add_all(orm_documents)
                     source_storage().store(corpus_name, document_instances)
+                    session.commit()
                 except Exception:
                     documents_not_ingested.extend(
                         documents[batch_number : batch_number + BATCH_SIZE]
                     )
                     session.rollback()
                 finally:
-                    session.commit()
                     session.close()
 
                 if not ignore_log:

--- a/ragna/deploy/_cli/corpus.py
+++ b/ragna/deploy/_cli/corpus.py
@@ -1,7 +1,7 @@
 import json
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Annotated, Optional
 
 import typer
 from rich.console import Console
@@ -22,31 +22,37 @@ app = typer.Typer(
 @app.command(help="Ingest some documents into a given corpus.")
 def ingest(
     documents: list[Path],
-    metadata_fields: Optional[Path] = typer.Option(
-        None,
-        help="JSON file that contains mappings from document name "
-        "to metadata fields associated with a document.",
-    ),
-    corpus_name: Optional[str] = typer.Option(
-        None, help="Name of the corpus to ingest the documents into."
-    ),
+    metadata_fields: Annotated[
+        Optional[Path],
+        typer.Option(
+            None,
+            help="JSON file that contains mappings from document name "
+            "to metadata fields associated with a document.",
+        ),
+    ] = None,
+    corpus_name: Annotated[
+        Optional[str],
+        typer.Option(help="Name of the corpus to ingest the documents into."),
+    ] = None,
     config: ConfigOption = "./ragna.toml",  # type: ignore[assignment]
-    user: Optional[str] = typer.Option(
-        None, help="User to link the documents to in the ragna database."
-    ),
-    report_failures: bool = typer.Option(
-        False, help="Output to STDERR the documents that failed to be ingested."
-    ),
-    ignore_log: bool = typer.Option(
-        False, help="Ignore the log file and re-ingest all documents."
-    ),
+    user: Annotated[
+        Optional[str],
+        typer.Option(help="User to link the documents to in the ragna database."),
+    ] = None,
+    report_failures: Annotated[
+        bool,
+        typer.Option(help="Output to STDERR the documents that failed to be ingested."),
+    ] = False,
+    ignore_log: Annotated[
+        bool, typer.Option(help="Ignore the log file and re-ingest all documents.")
+    ] = False,
 ) -> None:
     try:
         document_factory = getattr(config.document, "from_path")
     except AttributeError:
         raise typer.BadParameter(
-            f"{config.document.__name__} does not support creating documents from a path. "
-            "Please implement a `from_path` method."
+            f"{config.document.__name__} does not support creating documents from a"
+            f"path. Please implement a `from_path` method."
         )
 
     try:

--- a/ragna/deploy/_cli/corpus.py
+++ b/ragna/deploy/_cli/corpus.py
@@ -6,6 +6,7 @@ from typing import Annotated, Optional
 import rich
 import typer
 from rich.console import Console
+from rich.panel import Panel
 from rich.progress import BarColumn, Progress, TextColumn, TimeRemainingColumn
 
 from ragna.core._utils import default_user
@@ -23,16 +24,20 @@ app = typer.Typer(
 
 @app.callback()
 def experimental_warning():
-    rich.print(":rotating_light:" * 3)
+    lines = [
+        (
+            "[bold]ragna corpus[/bold] and all subcommands are in an experimental "
+            "state and subject to change in the future."
+        ),
+        (
+            "If you have feedback or want to suggest a feature, "
+            "please open an issue at "
+            "https://github.com/Quansight/ragna/issues/new/choose."
+        ),
+    ]
     rich.print(
-        "[bold]ragna corpus[/bold] and all subcommands are in an experimental "
-        "state and subject to change in the future."
+        Panel("\n".join(lines), title=":rotating_light: Warning :rotating_light:")
     )
-    rich.print(
-        "If you have feedback or want to suggest a feature, "
-        "please open an issue at https://github.com/Quansight/ragna/issues/new/choose"
-    )
-    rich.print(":rotating_light:" * 3)
 
 
 @app.command(help="Ingest documents into a given corpus.")

--- a/ragna/deploy/_cli/corpus.py
+++ b/ragna/deploy/_cli/corpus.py
@@ -23,7 +23,7 @@ app = typer.Typer(
 
 
 @app.callback()
-def experimental_warning():
+def experimental_warning() -> None:
     lines = [
         (
             "[bold]ragna corpus[/bold] and all subcommands are in an experimental "

--- a/ragna/deploy/_cli/corpus.py
+++ b/ragna/deploy/_cli/corpus.py
@@ -1,0 +1,191 @@
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.progress import BarColumn, Progress, TextColumn, TimeRemainingColumn
+
+from ragna.core._utils import default_user
+from ragna.deploy._api import database, orm
+
+from .config import ConfigOption
+
+app = typer.Typer(
+    name="corpus",
+    invoke_without_command=True,
+    no_args_is_help=True,
+)
+
+
+@app.command(help="Ingest some documents into a given corpus.")
+def ingest(
+    documents: list[Path],
+    metadata_fields: Optional[Path] = typer.Option(
+        None,
+        help="JSON file that contains mappings from document name "
+        "to metadata fields associated with a document.",
+    ),
+    corpus_name: Optional[str] = typer.Option(
+        None, help="Name of the corpus to ingest the documents into."
+    ),
+    config: ConfigOption = "./ragna.toml",  # type: ignore[assignment]
+    user: Optional[str] = typer.Option(
+        None, help="User to link the documents to in the ragna database."
+    ),
+    report_failures: bool = typer.Option(
+        False, help="Output to STDERR the documents that failed to be ingested."
+    ),
+    ignore_log: bool = typer.Option(
+        False, help="Ignore the log file and re-ingest all documents."
+    ),
+) -> None:
+    try:
+        document_factory = getattr(config.document, "from_path")
+    except AttributeError:
+        raise typer.BadParameter(
+            f"{config.document.__name__} does not support creating documents from a path. "
+            "Please implement a `from_path` method."
+        )
+
+    try:
+        make_session = database.get_sessionmaker(config.api.database_url)
+    except Exception:
+        raise typer.BadParameter(
+            f"Could not connect to the database: {config.api.database_url}"
+        )
+
+    if metadata_fields:
+        try:
+            with open(metadata_fields, "r") as f:
+                metadata = json.load(f)
+        except Exception:
+            raise typer.BadParameter(
+                f"Could not read the metadata fields file: {metadata_fields}"
+            )
+    else:
+        metadata = {}
+
+    if user is None:
+        user = default_user()
+    with make_session() as session:  # type: ignore[attr-defined]
+        user_id = database._get_user_id(session, user)
+
+    # Log (JSONL) for recording which files previously added to vector database.
+    # Each entry has keys for 'user', 'corpus_name', 'source_storage' and 'document'.
+    ingestion_log: dict[str, set[str]] = {}
+    if not ignore_log:
+        ingestion_log_file = Path.cwd() / ".ragna_ingestion_log.jsonl"
+        if ingestion_log_file.exists():
+            with open(ingestion_log_file, "r") as stream:
+                for line in stream:
+                    entry = json.loads(line)
+                    if entry["corpus_name"] == corpus_name and entry["user"] == user:
+                        ingestion_log.setdefault(entry["source_storage"], set()).add(
+                            entry["document"]
+                        )
+
+    with Progress(
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        "[progress.percentage]{task.percentage:>3.1f}%",
+        TimeRemainingColumn(),
+    ) as progress:
+        overall_task = progress.add_task(
+            "[cyan]Adding document embeddings to source storages...",
+            total=len(config.source_storages),
+        )
+
+        for source_storage in config.source_storages:
+            BATCH_SIZE = 10
+            number_of_batches = len(documents) // BATCH_SIZE
+            source_storage_task = progress.add_task(
+                f"[green]Adding document embeddings to {source_storage.__name__}...",
+                total=number_of_batches,
+            )
+
+            for batch_number in range(0, len(documents), BATCH_SIZE):
+                documents_not_ingested = []
+                document_instances = []
+                orm_documents = []
+
+                if source_storage.__name__ in ingestion_log:
+                    batch_doc_set = set(
+                        [
+                            str(doc)
+                            for doc in documents[
+                                batch_number : batch_number + BATCH_SIZE
+                            ]
+                        ]
+                    )
+                    if batch_doc_set.issubset(ingestion_log[source_storage.__name__]):
+                        progress.advance(source_storage_task)
+                        continue
+
+                for document in documents[batch_number : batch_number + BATCH_SIZE]:
+                    try:
+                        doc_instance = document_factory(
+                            document,
+                            metadata=(
+                                metadata[str(document)]
+                                if str(document) in metadata
+                                else None
+                            ),
+                        )
+                        document_instances.append(doc_instance)
+                        orm_documents.append(
+                            orm.Document(
+                                id=doc_instance.id,
+                                user_id=user_id,
+                                name=doc_instance.name,
+                                metadata_=doc_instance.metadata,
+                            )
+                        )
+                    except Exception:
+                        documents_not_ingested.append(document)
+
+                if not orm_documents:
+                    continue
+
+                try:
+                    session = make_session()
+                    session.add_all(orm_documents)
+                    source_storage().store(corpus_name, document_instances)
+                    session.commit()
+                except Exception:
+                    documents_not_ingested.extend(
+                        documents[batch_number : batch_number + BATCH_SIZE]
+                    )
+                    session.rollback()
+                finally:
+                    session.close()
+
+                if not ignore_log:
+                    with open(ingestion_log_file, "a") as stream:
+                        for document in documents[
+                            batch_number : batch_number + BATCH_SIZE
+                        ]:
+                            stream.write(
+                                json.dumps(
+                                    {
+                                        "user": user,
+                                        "corpus_name": corpus_name,
+                                        "source_storage": source_storage.__name__,
+                                        "document": str(document),
+                                    }
+                                )
+                                + "\n"
+                            )
+
+                if report_failures:
+                    Console(file=sys.stderr).print(
+                        f"{source_storage.__name__} failed to embed:\n{documents_not_ingested}",
+                    )
+
+                progress.advance(source_storage_task)
+
+            progress.update(source_storage_task, completed=number_of_batches)
+            progress.advance(overall_task)
+
+        progress.update(overall_task, completed=len(config.source_storages))

--- a/ragna/deploy/_cli/corpus.py
+++ b/ragna/deploy/_cli/corpus.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 from typing import Annotated, Optional
 
+import rich
 import typer
 from rich.console import Console
 from rich.progress import BarColumn, Progress, TextColumn, TimeRemainingColumn
@@ -14,9 +15,24 @@ from .config import ConfigOption
 
 app = typer.Typer(
     name="corpus",
+    help="(Experimental) Interact with a corpus of documents.",
     invoke_without_command=True,
     no_args_is_help=True,
 )
+
+
+@app.callback()
+def experimental_warning():
+    rich.print(":rotating_light:" * 3)
+    rich.print(
+        "[bold]ragna corpus[/bold] and all subcommands are in an experimental "
+        "state and subject to change in the future."
+    )
+    rich.print(
+        "If you have feedback or want to suggest a feature, "
+        "please open an issue at https://github.com/Quansight/ragna/issues/new/choose"
+    )
+    rich.print(":rotating_light:" * 3)
 
 
 @app.command(help="Ingest documents into a given corpus.")


### PR DESCRIPTION
PoC that addresses #488.

Based on a [gist](https://gist.github.com/pmeier/cc1576839d3a25389080dc214640c397) produced by @pmeier, as well as comments from #488.

An example usage from the current branch is:
```
ragna corpus ingest $(find MY_DOCUMENT_DIRECTORY -type f) --metadata-fields metadata.json --corpus-name MY_CORPUS_NAME --user UNAME --report-failures 2>> failures.txt

cat metadata.json
# {"MY_DOCUMENT_DIRECTORY/MY_FILE1": {"test_field": true}, "MY_DOCUMENT_DIRECTORY/MY_FILE2": {"test_field": false}}
```  