### PR TITLE
gracefully stop API when started by ragna ui

### DIFF
--- a/ragna/deploy/_cli/core.py
+++ b/ragna/deploy/_cli/core.py
@@ -148,7 +148,7 @@ def ui(
             stderr=sys.stderr,
         )
 
-        def shutdown_api():
+        def shutdown_api() -> None:
             process.terminate()
             process.communicate()
 

--- a/ragna/deploy/_cli/core.py
+++ b/ragna/deploy/_cli/core.py
@@ -1,3 +1,4 @@
+import signal
 import subprocess
 import sys
 import time
@@ -146,28 +147,37 @@ def ui(
             stdout=sys.stdout,
             stderr=sys.stderr,
         )
+
+        def shutdown_api():
+            process.terminate()
+            process.communicate()
+
+        @timeout_after(60)
+        def wait_for_api() -> None:
+            while not check_api_available():
+                time.sleep(0.5)
+
+        try:
+            wait_for_api()
+        except TimeoutError:
+            rich.print(
+                "Failed to start the API in 60 seconds. "
+                "Please start it manually with [bold]ragna api[/bold]."
+            )
+            shutdown_api()
+            raise typer.Exit(1)
     else:
-        process = None
+        shutdown_api = lambda: None  # noqa: E731
+
+    # By default Python does not handle the SIGTERM signal. Meaning, by default it would
+    # terminate the running process, i.e. the UI server, but not would not trigger the
+    # finally branch below and leave the API server running in case we have started it
+    # in a subprocess here.
+    # Thus, we turn SIGTERM in a regular exit, which gracefully triggers the finally
+    # branch.
+    signal.signal(signal.SIGTERM, lambda signum, frame: sys.exit())
 
     try:
-        if process is not None:
-
-            @timeout_after(60)
-            def wait_for_api() -> None:
-                while not check_api_available():
-                    time.sleep(0.5)
-
-            try:
-                wait_for_api()
-            except TimeoutError:
-                rich.print(
-                    "Failed to start the API in 60 seconds. "
-                    "Please start it manually with [bold]ragna api[/bold]."
-                )
-                raise typer.Exit(1)
-
         ui_app(config=config, open_browser=open_browser).serve()  # type: ignore[no-untyped-call]
     finally:
-        if process is not None:
-            process.kill()
-            process.communicate()
+        shutdown_api()

--- a/tests/deploy/ui/test_ui.py
+++ b/tests/deploy/ui/test_ui.py
@@ -3,7 +3,6 @@ import sys
 import time
 
 import httpx
-import panel as pn
 import pytest
 from playwright.sync_api import Page, expect
 
@@ -61,8 +60,8 @@ class Server:
             time.sleep(1)
 
     def stop(self):
-        self.proc.kill()
-        pn.state.kill_all_servers()
+        self.proc.terminate()
+        self.proc.communicate()
 
     def __enter__(self):
         self.start()


### PR DESCRIPTION
By default Python does not handle the SIGTERM signal. Thus, currently, when we send a SIGTERM to the process that was started by `ragna ui --start-api`, the `finally` branch that is supposed to stop the API is never run:

https://github.com/Quansight/ragna/blob/2066dcdeb949060873a8552449b848b245e0e985/ragna/deploy/_cli/core.py#L170-L173

Meaning, the Ragna API stays up:

```
❯ ragna ui --start-api &; sleep 10 && kill $! && sleep 10 && ps aux | grep ragna
[1] 22747
INFO:   RagnaDemoAuthentication: You can log in with any username and a matching password.
INFO:     Started server process [22773]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:31476 (Press CTRL+C to quit)
INFO:     127.0.0.1:54172 - "GET / HTTP/1.1" 200 OK
Launching server at http://127.0.0.1:31477
INFO:     127.0.0.1:58566 - "GET / HTTP/1.1" 200 OK
[1]  + 22747 terminated  ragna ui
philip     22773 22.8  0.5 1630504 358968 pts/0  SNl  11:01   0:04 /home/philip/.conda/envs/ragna-deploy-dev/bin/python3.9 -m ragna api --config ./ragna.toml --no-ignore-unavailable-components
```

This pronounced in our test suite where each UI test spawns the Ragna API, but it never gets cleaned up

```
❯ pytest tests/deploy/ui --quiet && ps aux | grep ragna
..                                                                                                 [100%]
2 passed in 11.99s
philip     25447 35.7  0.2 1139644 195568 pts/0  Sl   11:11   0:03 /home/philip/.conda/envs/ragna-deploy-dev/bin/python -m ragna api --config /tmp/pytest-of-philip/pytest-26/test_health_chromium_0/ragna.toml --ignore-unavailable-components
philip     25521 68.2  0.3 1290196 199060 pts/0  Sl   11:11   0:03 /home/philip/.conda/envs/ragna-deploy-dev/bin/python -m ragna api --config /tmp/pytest-of-philip/pytest-26/test_start_chat_chromium_0/ragna.toml --ignore-unavailable-components
```

This PR turns the SIGTERM signal in a regular system exit for `ragna ui` and thus enables graceful shutdown.

```
❯ ragna ui --start-api &; sleep 10 && kill $! && sleep 10 && ps aux | grep ragna
[1] 25853
INFO:   RagnaDemoAuthentication: You can log in with any username and a matching password.
INFO:     Started server process [25879]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:31476 (Press CTRL+C to quit)
INFO:     127.0.0.1:49790 - "GET / HTTP/1.1" 200 OK
Launching server at http://127.0.0.1:31477
INFO:     Shutting down
INFO:     Waiting for application shutdown.
INFO:     Application shutdown complete.
INFO:     Finished server process [25879]
[1]  + 25853 done       ragna ui --start-api
```