### PR TITLE
handle zombie processes in docs

### DIFF
--- a/docs/tutorials/gallery_custom_components.py
+++ b/docs/tutorials/gallery_custom_components.py
@@ -322,7 +322,7 @@ config = Config(
 rest_api = ragna_docs.RestApi()
 
 client, document = rest_api.start(config, authenticate=True, upload_document=True)
-raise Exception
+
 # %%
 # To pass custom parameters, define them in the `params` mapping when creating a new
 # chat.

--- a/docs/tutorials/gallery_custom_components.py
+++ b/docs/tutorials/gallery_custom_components.py
@@ -322,7 +322,7 @@ config = Config(
 rest_api = ragna_docs.RestApi()
 
 client, document = rest_api.start(config, authenticate=True, upload_document=True)
-
+raise Exception
 # %%
 # To pass custom parameters, define them in the `params` mapping when creating a new
 # chat.

--- a/ragna/_docs.py
+++ b/ragna/_docs.py
@@ -1,3 +1,4 @@
+import atexit
 import inspect
 import itertools
 import os
@@ -49,6 +50,9 @@ class RestApi:
         client = httpx.Client(base_url=config.api.url)
 
         self._process = self._start_api(config_path, python_path, client)
+        # In case the documentation errors before we call RestApi.stop, we still need to
+        # stop the server to avoid zombie processes
+        atexit.register(self.stop, quiet=True)
 
         if authenticate:
             self._authenticate(client)
@@ -179,6 +183,3 @@ class RestApi:
 
         if not quiet:
             print(stdout.decode())
-
-    def __del__(self) -> None:
-        self.stop(quiet=True)

--- a/ragna/_docs.py
+++ b/ragna/_docs.py
@@ -32,6 +32,9 @@ https://github.com/Quansight/ragna under the BSD 3-Clause license.
 class RestApi:
     def __init__(self) -> None:
         self._process: Optional[subprocess.Popen] = None
+        # In case the documentation errors before we call RestApi.stop, we still need to
+        # stop the server to avoid zombie processes
+        atexit.register(self.stop, quiet=True)
 
     def start(
         self,
@@ -50,9 +53,6 @@ class RestApi:
         client = httpx.Client(base_url=config.api.url)
 
         self._process = self._start_api(config_path, python_path, client)
-        # In case the documentation errors before we call RestApi.stop, we still need to
-        # stop the server to avoid zombie processes
-        atexit.register(self.stop, quiet=True)
 
         if authenticate:
             self._authenticate(client)

--- a/ragna/_docs.py
+++ b/ragna/_docs.py
@@ -178,7 +178,7 @@ class RestApi:
         if self._process is None:
             return
 
-        self._process.kill()
+        self._process.terminate()
         stdout, _ = self._process.communicate()
 
         if not quiet:


### PR DESCRIPTION
Follow-up to #496. If the documentation build errors and we never get to calling `RestApi.stop()`, we have a zombie RestAPI process. However, here it is even worse than for the tests in #496: since we are not randomizing the port number, the next time we build the docs, the old REST API is still available and will be picked up instead of starting a fresh one invalidating most of the assumptions that we make, e.g. no chats available after startup.