### PR TITLE
improve corpus UX and fix docs

### DIFF
--- a/docs/examples/gallery_streaming.py
+++ b/docs/examples/gallery_streaming.py
@@ -119,7 +119,7 @@ chat = (
         "/chats",
         json={
             "name": "Tutorial REST API",
-            "documents": [document],
+            "input": [document],
             "source_storage": source_storages.RagnaDemoSourceStorage.display_name(),
             "assistant": DemoStreamingAssistant.display_name(),
             "params": {},

--- a/docs/tutorials/gallery_rest_api.py
+++ b/docs/tutorials/gallery_rest_api.py
@@ -158,7 +158,7 @@ response = client.post(
     "/chats",
     json={
         "name": "Tutorial REST API",
-        "documents": [document],
+        "input": [document],
         "source_storage": source_storage,
         "assistant": assistant,
         "params": {},

--- a/ragna/__init__.py
+++ b/ragna/__init__.py
@@ -13,10 +13,11 @@ from ._utils import local_root
 # isort: split
 
 from . import assistants, core, deploy, source_storages
-from .core import Rag
+from .core import MetadataFilter, Rag
 
 __all__ = [
     "__version__",
+    "MetadataFilter",
     "Rag",
     "assistants",
     "core",

--- a/ragna/core/_components.py
+++ b/ragna/core/_components.py
@@ -130,7 +130,7 @@ class SourceStorage(Component, abc.ABC):
     __ragna_protocol_methods__ = ["store", "retrieve"]
 
     @abc.abstractmethod
-    def store(self, corpus_name: Optional[str], documents: list[Document]) -> None:
+    def store(self, corpus_name: str, documents: list[Document]) -> None:
         """Store content of documents.
 
         Args:
@@ -141,7 +141,7 @@ class SourceStorage(Component, abc.ABC):
 
     @abc.abstractmethod
     def retrieve(
-        self, corpus_name: Optional[str], metadata_filter: MetadataFilter, prompt: str
+        self, corpus_name: str, metadata_filter: MetadataFilter, prompt: str
     ) -> list[Source]:
         """Retrieve sources for a given prompt.
 

--- a/ragna/core/_metadata_filter.py
+++ b/ragna/core/_metadata_filter.py
@@ -9,6 +9,10 @@ import pydantic_core
 
 
 class MetadataOperator(enum.Enum):
+    """
+    ADDME
+    """
+
     RAW = enum.auto()
     AND = enum.auto()
     OR = enum.auto()
@@ -23,6 +27,10 @@ class MetadataOperator(enum.Enum):
 
 
 class MetadataFilter:
+    """
+    ADDME
+    """
+
     def __init__(self, operator: MetadataOperator, key: str, value: Any) -> None:
         self.operator = operator
         self.key = key

--- a/ragna/deploy/_api/orm.py
+++ b/ragna/deploy/_api/orm.py
@@ -102,7 +102,7 @@ class Chat(Base):
     )
     source_storage = Column(types.String, nullable=False)
     assistant = Column(types.String, nullable=False)
-    corpus_name = Column(types.String, nullable=True)
+    corpus_name = Column(types.String, nullable=False)
     params = Column(Json, nullable=False)
     messages = relationship(
         "Message", cascade="all, delete", order_by="Message.timestamp"

--- a/ragna/deploy/_api/schemas.py
+++ b/ragna/deploy/_api/schemas.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 import uuid
-from typing import Any, Optional, Union
+from typing import Any, Union
 
 from pydantic import BaseModel, Field
 
@@ -101,8 +101,8 @@ class ChatMetadata(BaseModel):
     source_storage: str
     assistant: str
     params: dict
-    input: Union[None, ragna.core.MetadataFilter, list[Document]]
-    corpus_name: Optional[str] = None
+    input: Union[None, ragna.core.MetadataFilter, list[Document]] = None
+    corpus_name: str = "default"
 
 
 class Chat(BaseModel):

--- a/ragna/source_storages/_chroma.py
+++ b/ragna/source_storages/_chroma.py
@@ -36,8 +36,8 @@ class Chroma(VectorDatabaseSourceStorage):
             )
         )
 
-    def _get_collection(self, corpus_name: Optional[str]) -> chromadb.Collection:
-        if corpus_name is None:
+    def _get_collection(self, corpus_name: str) -> chromadb.Collection:
+        if corpus_name == "default":
             corpus_name = self._embedding_id
 
         return self._client.get_or_create_collection(
@@ -46,7 +46,7 @@ class Chroma(VectorDatabaseSourceStorage):
 
     def store(
         self,
-        corpus_name: Optional[str],
+        corpus_name: str,
         documents: list[Document],
         *,
         chunk_size: int = 500,
@@ -123,7 +123,7 @@ class Chroma(VectorDatabaseSourceStorage):
 
     def retrieve(
         self,
-        corpus_name: Optional[str],
+        corpus_name: str,
         metadata_filter: MetadataFilter,
         prompt: str,
         *,

--- a/ragna/source_storages/_demo.py
+++ b/ragna/source_storages/_demo.py
@@ -3,6 +3,8 @@ import textwrap
 import uuid
 from typing import Any, Callable, Optional, cast
 
+from fastapi import status
+
 from ragna.core import (
     Document,
     MetadataFilter,
@@ -29,10 +31,11 @@ class RagnaDemoSourceStorage(SourceStorage):
         return "Ragna/DemoSourceStorage"
 
     def __init__(self) -> None:
-        self._storage: dict[Optional[str], list[dict[str, Any]]] = {None: []}
+        self._storage: dict[str, list[dict[str, Any]]] = {}
 
-    def store(self, corpus_name: Optional[str], documents: list[Document]) -> None:
-        self._storage[None].extend(
+    def store(self, corpus_name: str, documents: list[Document]) -> None:
+        corpus = self._storage.setdefault(corpus_name, [])
+        corpus.extend(
             [
                 dict(
                     document_id=str(document.id),
@@ -63,10 +66,10 @@ class RagnaDemoSourceStorage(SourceStorage):
     }
 
     def _apply_filter(
-        self, metadata_filter: Optional[MetadataFilter]
+        self, corpus: list[dict[str, Any]], metadata_filter: Optional[MetadataFilter]
     ) -> list[tuple[int, dict[str, Any]]]:
         if metadata_filter is None:
-            return list(enumerate(self._storage[None]))
+            return list(enumerate(corpus))
         elif metadata_filter.operator is MetadataOperator.RAW:
             raise RagnaException
         elif metadata_filter.operator in {MetadataOperator.AND, MetadataOperator.OR}:
@@ -74,7 +77,7 @@ class RagnaDemoSourceStorage(SourceStorage):
             rows_map = {}
             for child in metadata_filter.value:
                 idcs_group = set()
-                for idx, row in self._apply_filter(child):
+                for idx, row in self._apply_filter(corpus, child):
                     idcs_group.add(idx)
                     if idx not in rows_map:
                         rows_map[idx] = row
@@ -93,7 +96,7 @@ class RagnaDemoSourceStorage(SourceStorage):
             return [(idx, rows_map[idx]) for idx in sorted(idcs)]
         else:
             rows_with_idx = []
-            for idx, row in enumerate(self._storage[None]):
+            for idx, row in enumerate(corpus):
                 value = row.get(metadata_filter.key)
                 if value is None:
                     continue
@@ -106,8 +109,16 @@ class RagnaDemoSourceStorage(SourceStorage):
             return rows_with_idx
 
     def retrieve(
-        self, corpus_name: Optional[str], metadata_filter: MetadataFilter, prompt: str
+        self, corpus_name: str, metadata_filter: MetadataFilter, prompt: str
     ) -> list[Source]:
+        corpus = self._storage.get(corpus_name)
+        if corpus is None:
+            raise RagnaException(
+                "Corpus does not exist",
+                corpus_name=corpus_name,
+                http_status_code=status.HTTP_400_BAD_REQUEST,
+                http_detail=RagnaException.MESSAGE,
+            )
         return [
             Source(
                 id=row["__id__"],
@@ -117,5 +128,5 @@ class RagnaDemoSourceStorage(SourceStorage):
                 content=row["__content__"],
                 num_tokens=row["__num_tokens__"],
             )
-            for _, row in self._apply_filter(metadata_filter)
+            for _, row in self._apply_filter(corpus, metadata_filter)
         ]

--- a/ragna/source_storages/_lancedb.py
+++ b/ragna/source_storages/_lancedb.py
@@ -52,8 +52,8 @@ class LanceDB(VectorDatabaseSourceStorage):
 
     _VECTOR_COLUMN_NAME = "embedded_text"
 
-    def _get_table(self, corpus_name: Optional[str] = None) -> lancedb.table.Table:
-        if corpus_name is None:
+    def _get_table(self, corpus_name: str) -> lancedb.table.Table:
+        if corpus_name == "default":
             corpus_name = self._embedding_id
 
         if corpus_name in self._db.table_names():
@@ -88,7 +88,7 @@ class LanceDB(VectorDatabaseSourceStorage):
 
     def store(
         self,
-        corpus_name: Optional[str],
+        corpus_name: str,
         documents: list[Document],
         *,
         chunk_size: int = 500,
@@ -192,7 +192,7 @@ class LanceDB(VectorDatabaseSourceStorage):
 
     def retrieve(
         self,
-        corpus_name: Optional[str],
+        corpus_name: str,
         metadata_filter: Optional[MetadataFilter],
         prompt: str,
         *,

--- a/tests/core/test_e2e.py
+++ b/tests/core/test_e2e.py
@@ -15,7 +15,6 @@ def test_e2e(tmp_local_root, input_type):
             input=input,
             source_storage=source_storage,
             assistant=assistant,
-            corpus_name=None,
         ) as chat:
             return await chat.answer("?")
 
@@ -31,7 +30,7 @@ def test_e2e(tmp_local_root, input_type):
     if input_type == "documents":
         input = [document]
     else:
-        source_storage.store(None, [document])
+        source_storage.store("default", [document])
 
         if input_type == "corpus":
             input = None

--- a/tests/core/test_rag.py
+++ b/tests/core/test_rag.py
@@ -24,7 +24,6 @@ class TestChat:
             input=documents,
             source_storage=source_storage,
             assistant=assistant,
-            corpus_name="test-corpus",
             **params,
         )
 

--- a/tests/deploy/api/test_e2e.py
+++ b/tests/deploy/api/test_e2e.py
@@ -12,7 +12,7 @@ from tests.utils import skip_on_windows
 @skip_on_windows
 @pytest.mark.parametrize("multiple_answer_chunks", [True, False])
 @pytest.mark.parametrize("stream_answer", [True, False])
-@pytest.mark.parametrize("corpus_name", ["test-corpus", None])
+@pytest.mark.parametrize("corpus_name", ["default", "test-corpus"])
 def test_e2e(tmp_local_root, multiple_answer_chunks, stream_answer, corpus_name):
     config = Config(local_root=tmp_local_root, assistants=[TestAssistant])
 

--- a/tests/source_storages/test_source_storages.py
+++ b/tests/source_storages/test_source_storages.py
@@ -109,12 +109,14 @@ def test_smoke(tmp_local_root, source_storage_cls, metadata_filter, expected_idc
         )
 
     source_storage = source_storage_cls()
-    source_storage.store("test-corpus", documents)
+    corpus_name = "default"
+
+    source_storage.store(corpus_name, documents)
 
     prompt = "What is the secret number?"
     num_tokens = 4096
     sources = source_storage.retrieve(
-        corpus_name="test-corpus",
+        corpus_name=corpus_name,
         metadata_filter=metadata_filter,
         prompt=prompt,
         num_tokens=num_tokens,
@@ -124,7 +126,7 @@ def test_smoke(tmp_local_root, source_storage_cls, metadata_filter, expected_idc
     assert actual_idcs == expected_idcs
 
     # Should be able to call .store() multiple times
-    source_storage.store("test-corpus", documents)
+    source_storage.store(corpus_name, documents)
 
 
 @pytest.mark.parametrize("source_storage_cls", [Chroma, LanceDB])
@@ -132,14 +134,17 @@ def test_corpus_names(tmp_local_root, source_storage_cls):
     document_root = tmp_local_root / "documents"
     document_root.mkdir()
 
+    secret_corpus_name = "secret_corpus"
     secret_path = document_root / "secret_doc"
+    secret = "42"
     with open(secret_path, "w") as file:
-        file.write("The secret number is 42!\n")
+        file.write(f"The secret is {secret}!\n")
     secret_document = LocalDocument.from_path(
         secret_path,
         handler=PlainTextDocumentHandler(),
     )
 
+    dummy_corpus_name = "dummy_corpus"
     dummy_path = document_root / "dummy_doc"
     with open(dummy_path, "w") as file:
         file.write("Dummy Doc!\n")
@@ -149,27 +154,25 @@ def test_corpus_names(tmp_local_root, source_storage_cls):
     )
 
     source_storage = source_storage_cls()
-    source_storage.store("test-corpus-secret", [secret_document])
 
-    source_storage = source_storage_cls()
-    source_storage.store("test-corpus-dummy", [dummy_document])
+    source_storage.store(secret_corpus_name, [secret_document])
+    source_storage.store(dummy_corpus_name, [dummy_document])
 
     prompt = "What is the secret number?"
     num_tokens = 4096
+
     secret_sources = source_storage.retrieve(
-        corpus_name="test-corpus-secret",
+        corpus_name=secret_corpus_name,
         prompt=prompt,
         metadata_filter=None,
         num_tokens=num_tokens,
     )
-    assert "The secret number is 42" in secret_sources[0].content
+    assert secret in secret_sources[0].content
 
-    prompt = "What is the secret number?"
-    num_tokens = 4096
-    secret_sources = source_storage.retrieve(
-        corpus_name="test-corpus-dummy",
+    dummy_sources = source_storage.retrieve(
+        corpus_name=dummy_corpus_name,
         prompt=prompt,
         metadata_filter=None,
         num_tokens=num_tokens,
     )
-    assert "The secret number is 42" not in secret_sources[0].content
+    assert secret not in dummy_sources[0].content


### PR DESCRIPTION
- Fix the doc builds so CI is green again. This does _not_ add proper docs just stubs so we can see if other PRs to the `corpus-dev` branch break the documentation. This supersedes #494.
- Remove the `corpus_name=None`  sentinel and use `corpus_name="default"` instead. See https://github.com/Quansight/ragna/issues/493#issuecomment-2298153629
- Add the default value for `corpus_name="default"` when creating a chat to avoid forcing users to pass something. The default handling is thus pushed to the author of the source storage.
- Add the default value for `input=None` when creating a chat. This way users with a corpus of documents can just ask away. I've added proper error handling in case we are unable to retrieve any sources.
- Add support for passing a single document or path as input when creating a chat