### PR TITLE
Fix #504 : honor the indentation in the MetadataFilter formatting 

### DIFF
--- a/ragna/deploy/_ui/central_view.py
+++ b/ragna/deploy/_ui/central_view.py
@@ -205,10 +205,16 @@ class CentralView(pn.viewable.Viewer):
             # `MetadataFilter`s provided as dict
             title = "Metadata Filters"
 
-            metadata_filters_readable = str(
-                MetadataFilter.from_primitive(self.current_chat["metadata"]["input"])
-            ).replace("\n", "<br>").replace(" ", "&nbsp;")
-            
+            metadata_filters_readable = (
+                str(
+                    MetadataFilter.from_primitive(
+                        self.current_chat["metadata"]["input"]
+                    )
+                )
+                .replace("\n", "<br>")
+                .replace(" ", "&nbsp;")
+            )
+
             details = f"<div class='details details_block' style='display:block;'><pre>{metadata_filters_readable}</pre></div><br />\n\n"
             grid_height = 1
 

--- a/ragna/deploy/_ui/central_view.py
+++ b/ragna/deploy/_ui/central_view.py
@@ -207,9 +207,9 @@ class CentralView(pn.viewable.Viewer):
 
             metadata_filters_readable = str(
                 MetadataFilter.from_primitive(self.current_chat["metadata"]["input"])
-            ).replace("\n", "<br>")
-
-            details = f"<div class='details details_block' style='display:block;'>{metadata_filters_readable}</div><br />\n\n"
+            ).replace("\n", "<br>").replace(" ", "&nbsp;")
+            
+            details = f"<div class='details details_block' style='display:block;'><pre>{metadata_filters_readable}</pre></div><br />\n\n"
             grid_height = 1
 
         elif self.current_chat["metadata"]["input"] is None:

--- a/ragna/deploy/_ui/css/chat_info/markdown.css
+++ b/ragna/deploy/_ui/css/chat_info/markdown.css
@@ -24,3 +24,11 @@
 :host(.chat_info_markdown) ul {
   list-style-type: none;
 }
+
+:host(.chat_info_markdown) .details_block pre {
+  width: calc(100% - 10px) ;
+  overflow-x: scroll;
+  padding-right:10px;
+  margin-right:10px;
+
+}

--- a/ragna/deploy/_ui/css/chat_info/markdown.css
+++ b/ragna/deploy/_ui/css/chat_info/markdown.css
@@ -26,9 +26,8 @@
 }
 
 :host(.chat_info_markdown) .details_block pre {
-  width: calc(100% - 10px) ;
+  width: calc(100% - 10px);
   overflow-x: scroll;
-  padding-right:10px;
-  margin-right:10px;
-
+  padding-right: 10px;
+  margin-right: 10px;
 }


### PR DESCRIPTION
Fix #504 : honor the indentation in the MetadataFilter formatting 