### PR TITLE
install bokeh_fastapi through panel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,15 +22,12 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "aiofiles",
-    # Remove this and instead depend on panel[fastapi]
-    # after https://github.com/holoviz/panel/pull/7495 is released
-    "bokeh_fastapi==0.1.1",
     "emoji",
     "eval_type_backport; python_version<'3.10'",
     "fastapi",
     "httpx",
     "packaging",
-    "panel==1.5.4",
+    "panel[fastapi]==1.5.4",
     "pydantic>=2",
     "pydantic-core",
     "pydantic-settings>=2",


### PR DESCRIPTION
I just pushed `bokeh_fastapi==0.1.2`, which makes holoviz/panel#7495 obsolete.