### PR TITLE
fix open browser functionality

### DIFF
--- a/ragna/deploy/_core.py
+++ b/ragna/deploy/_core.py
@@ -40,8 +40,16 @@ def make_app(
 
         @contextlib.asynccontextmanager
         async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+            try:
+                browser = webbrowser.get()
+            except webbrowser.Error as error:
+                print(str(error))
+                yield
+                return
+
             def target() -> None:
-                client = httpx.Client(base_url=config._url)
+                url = f"http://{config.hostname}:{config.port}"
+                client = httpx.Client(base_url=url)
 
                 def server_available() -> bool:
                     try:
@@ -52,7 +60,7 @@ def make_app(
                 while not server_available():
                     time.sleep(0.1)
 
-                webbrowser.open(config._url)
+                browser.open(url)
 
             # We are starting the browser on a thread, because the server can only
             # become available _after_ the yield below. By setting daemon=True, the


### PR DESCRIPTION
1. If there is no browser available, we can't open one.
2. Since the health check is coming from the same machine and thus doesn't see any proxy, we cannot use `config._url` since that includes the `root_path`.