### PR TITLE
Upgrade ChromaDB to >=0.6.0 and fix broken tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ Repository = "https://github.com/Quansight/ragna"
 [project.optional-dependencies]
 # to update the array below, run scripts/update_optional_dependencies.py
 all = [
-    "chromadb<=0.5.11,>=0.4.13",
+    "chromadb>=0.6.0",
     "httpx_sse",
     "ijson",
     "lancedb>=0.2",

--- a/ragna/source_storages/_chroma.py
+++ b/ragna/source_storages/_chroma.py
@@ -26,7 +26,7 @@ class Chroma(VectorDatabaseSourceStorage):
         The `NE` and `NOT_IN` metadata filter operators behave differently in Chroma
         than the other builtin source storages. With most other source storages,
         given a key-value pair `(key, value)`, the operators `NE` and `NOT_IN` return
-        only the source's metadata pairs with a key `key` and a value not equal to or
+        only the sources with a metadata key `key` and a value not equal to or
         not in, respectively, `value`. To contrast, the `NE` and `NOT_IN` metadata filter
         operators in `ChromaDB` return everything described in the preceding sentence,
         together with all sources that do not have the metadata key `key`.

--- a/ragna/source_storages/_chroma.py
+++ b/ragna/source_storages/_chroma.py
@@ -39,7 +39,7 @@ class Chroma(VectorDatabaseSourceStorage):
         )
 
     def list_corpuses(self) -> list[str]:
-        return [collection.name for collection in self._client.list_collections()]
+        return self._client.list_collections()
 
     def _get_collection(
         self, corpus_name: str, *, create: bool = False

--- a/ragna/source_storages/_chroma.py
+++ b/ragna/source_storages/_chroma.py
@@ -24,16 +24,15 @@ class Chroma(VectorDatabaseSourceStorage):
     !!! warning
 
         The `NE` and `NOT_IN` metadata filter operators behave differently in Chroma
-        than they do in most other source storages. With most other source storages,
+        than the other builtin source storages. With most other source storages,
         given a key-value pair `(key, value)`, the operators `NE` and `NOT_IN` return
-        only the key-value pairs with a key `key` and a value not equal to or not in,
-        respectively, `value`. To contrast, the `NE` and `NOT_IN` metadata filter
-        operators in ChromaDB return everything described in the preceding sentence,
-        together with all key-value pairs `(other_key, other_value)` where `key` is
-        not equal to `other_key`.
+        only the source's metadata pairs with a key `key` and a value not equal to or
+        not in, respectively, `value`. To contrast, the `NE` and `NOT_IN` metadata filter
+        operators in `ChromaDB` return everything described in the preceding sentence,
+        together with all sources that do not have the metadata key `key`.
 
-        For more information, see the notes for v0.5.12 in the
-        [ChromaDB migration guide](https://docs.trychroma.com/production/administration/migration).
+        For more information, see the notes for `v0.5.12` in the
+        [`ChromaDB` migration guide](https://docs.trychroma.com/production/administration/migration).
     """
 
     # Note that this class has no extra requirements, since the chromadb package is

--- a/ragna/source_storages/_chroma.py
+++ b/ragna/source_storages/_chroma.py
@@ -39,7 +39,7 @@ class Chroma(VectorDatabaseSourceStorage):
         )
 
     def list_corpuses(self) -> list[str]:
-        return self._client.list_collections()
+        return [str(c) for c in self._client.list_collections()]
 
     def _get_collection(
         self, corpus_name: str, *, create: bool = False
@@ -49,13 +49,13 @@ class Chroma(VectorDatabaseSourceStorage):
                 corpus_name, embedding_function=self._embedding_function
             )
 
-        collections = list(self._client.list_collections())
-        if not collections:
+        corpuses = self.list_corpuses()
+        if not corpuses:
             raise_no_corpuses_available(self)
 
         try:
             return self._client.get_collection(
-                name=next(name for name in collections if name == corpus_name),
+                name=next(name for name in corpuses if name == corpus_name),
                 embedding_function=self._embedding_function,
             )
         except StopIteration:

--- a/ragna/source_storages/_chroma.py
+++ b/ragna/source_storages/_chroma.py
@@ -19,7 +19,7 @@ class Chroma(VectorDatabaseSourceStorage):
 
     !!! info "Required packages"
 
-        - `chromadb>=0.4.13`
+        - `chromadb>=0.6.0`
 
     !!! warning
 

--- a/ragna/source_storages/_chroma.py
+++ b/ragna/source_storages/_chroma.py
@@ -20,6 +20,20 @@ class Chroma(VectorDatabaseSourceStorage):
     !!! info "Required packages"
 
         - `chromadb>=0.4.13`
+
+    !!! warning
+
+        The `NE` and `NOT_IN` metadata filter operators behave differently in Chroma
+        than they do in most other source storages. With most other source storages,
+        given a key-value pair `(key, value)`, the operators `NE` and `NOT_IN` return
+        only the key-value pairs with a key `key` and a value not equal to or not in,
+        respectively, `value`. To contrast, the `NE` and `NOT_IN` metadata filter
+        operators in ChromaDB return everything described in the preceding sentence,
+        together with all key-value pairs `(other_key, other_value)` where `key` is
+        not equal to `other_key`.
+
+        For more information, see the notes for v0.5.12 in the
+        [ChromaDB migration guide](https://docs.trychroma.com/production/administration/migration).
     """
 
     # Note that this class has no extra requirements, since the chromadb package is

--- a/ragna/source_storages/_chroma.py
+++ b/ragna/source_storages/_chroma.py
@@ -54,10 +54,9 @@ class Chroma(VectorDatabaseSourceStorage):
             raise_no_corpuses_available(self)
 
         try:
-            return next(
-                collection
-                for collection in collections
-                if collection.name == corpus_name
+            return self._client.get_collection(
+                name=next(name for name in collections if name == corpus_name),
+                embedding_function=self._embedding_function,
             )
         except StopIteration:
             raise_non_existing_corpus(self, corpus_name)

--- a/ragna/source_storages/_lancedb.py
+++ b/ragna/source_storages/_lancedb.py
@@ -27,7 +27,7 @@ class LanceDB(VectorDatabaseSourceStorage):
 
     !!! info "Required packages"
 
-        - `chromadb>=0.4.13`
+        - `chromadb>=0.6.0`
         - `lancedb>=0.2`
         - `pyarrow`
     """

--- a/ragna/source_storages/_vector_database.py
+++ b/ragna/source_storages/_vector_database.py
@@ -46,7 +46,7 @@ class VectorDatabaseSourceStorage(SourceStorage):
             # to manage and mostly not even used by the vector DB. Chroma provides a
             # wrapper around a compiled embedding function that has only minimal
             # requirements. We use this as base for all of our Vector DBs.
-            PackageRequirement("chromadb<=0.5.11,>=0.4.13"),
+            PackageRequirement("chromadb<=0.6.1,>=0.4.13"),
             PackageRequirement("tiktoken"),
         ]
 

--- a/ragna/source_storages/_vector_database.py
+++ b/ragna/source_storages/_vector_database.py
@@ -46,7 +46,7 @@ class VectorDatabaseSourceStorage(SourceStorage):
             # to manage and mostly not even used by the vector DB. Chroma provides a
             # wrapper around a compiled embedding function that has only minimal
             # requirements. We use this as base for all of our Vector DBs.
-            PackageRequirement("chromadb<=0.6.1,>=0.4.13"),
+            PackageRequirement("chromadb>=0.6.0"),
             PackageRequirement("tiktoken"),
         ]
 

--- a/tests/source_storages/test_source_storages.py
+++ b/tests/source_storages/test_source_storages.py
@@ -69,7 +69,9 @@ metadata_filters = pytest.mark.parametrize(
                     MetadataFilter.and_(
                         [
                             MetadataFilter.eq("key", "other_value"),
-                            MetadataFilter.ne("other_key", "other_value"),
+                            MetadataFilter.in_(
+                                "other_key", ["some_value", "other_value"]
+                            ),
                         ]
                     ),
                 ]
@@ -105,7 +107,6 @@ def _xfail_chroma_ne_nin(request):
     fixture_values = frozenset(request.node.callspec._idlist)
 
     xfail_filters = {
-        frozenset(("Chroma", "or-nested")),
         frozenset(("Chroma", "ne")),
         frozenset(("Chroma", "not_in")),
     }

--- a/tests/source_storages/test_source_storages.py
+++ b/tests/source_storages/test_source_storages.py
@@ -116,7 +116,7 @@ def _patch_chroma_ne_nin(request):
 
 
 @metadata_filters
-@pytest.mark.parametrize("source_storage_cls", [Chroma])  # LanceDB
+@pytest.mark.parametrize("source_storage_cls", [Chroma, LanceDB])
 @pytest.mark.usefixtures("_patch_chroma_ne_nin")
 def test_smoke(tmp_local_root, source_storage_cls, metadata_filter, expected_idcs):
     document_root = tmp_local_root / "documents"

--- a/tests/source_storages/test_source_storages.py
+++ b/tests/source_storages/test_source_storages.py
@@ -103,21 +103,21 @@ metadata_filters = pytest.mark.parametrize(
 
 
 @pytest.fixture
-def _xfail_chroma_ne_nin(request):
+def _patch_chroma_ne_nin(request):
     fixture_values = frozenset(request.node.callspec._idlist)
 
-    xfail_filters = {
-        frozenset(("Chroma", "ne")),
-        frozenset(("Chroma", "not_in")),
+    patch_filters = {
+        frozenset(("Chroma", "ne")): [2, 3, 4, 5, 6],
+        frozenset(("Chroma", "not_in")): [0, 1, 2, 3, 4],
     }
 
-    if fixture_values in xfail_filters:
-        request.node.add_marker(pytest.mark.xfail())
+    if fixture_values in patch_filters.keys():
+        request.node.callspec.params["expected_idcs"] = patch_filters[fixture_values]
 
 
 @metadata_filters
 @pytest.mark.parametrize("source_storage_cls", [Chroma])  # LanceDB
-@pytest.mark.usefixtures("_xfail_chroma_ne_nin")
+@pytest.mark.usefixtures("_patch_chroma_ne_nin")
 def test_smoke(tmp_local_root, source_storage_cls, metadata_filter, expected_idcs):
     document_root = tmp_local_root / "documents"
     document_root.mkdir()

--- a/tests/source_storages/test_source_storages.py
+++ b/tests/source_storages/test_source_storages.py
@@ -152,6 +152,19 @@ def test_smoke(tmp_local_root, source_storage_cls, metadata_filter, expected_idc
     source_storage.store(corpus_name, documents)
 
 
+@pytest.mark.parametrize(
+    "metadata_filter,expected_idcs",
+    [
+        pytest.param(MetadataFilter.ne("key", "value"), [2, 3, 4, 5, 6], id="ne"),
+        pytest.param(
+            MetadataFilter.not_in("key", ["foo", "bar"]), [0, 1, 2, 3, 4], id="not_in"
+        ),
+    ],
+)
+def test_smoke_chroma_ne_nin(tmp_local_root, metadata_filter, expected_idcs):
+    test_smoke(tmp_local_root, Chroma, metadata_filter, expected_idcs)
+
+
 @pytest.mark.parametrize("source_storage_cls", [Chroma, LanceDB])
 def test_corpus_names(tmp_local_root, source_storage_cls):
     document_root = tmp_local_root / "documents"

--- a/tests/source_storages/test_source_storages.py
+++ b/tests/source_storages/test_source_storages.py
@@ -105,7 +105,13 @@ metadata_filters = pytest.mark.parametrize(
 
 @metadata_filters
 @pytest.mark.parametrize("source_storage_cls", [Chroma, LanceDB])
-def test_smoke(tmp_local_root, source_storage_cls, metadata_filter, expected_idcs):
+def test_smoke(
+    tmp_local_root,
+    source_storage_cls,
+    metadata_filter,
+    expected_idcs,
+    chroma_override=False,
+):
     document_root = tmp_local_root / "documents"
     document_root.mkdir()
     documents = []
@@ -136,14 +142,17 @@ def test_smoke(tmp_local_root, source_storage_cls, metadata_filter, expected_idc
         num_tokens=num_tokens,
     )
 
-    if not (
-        source_storage_cls is Chroma
-        and isinstance(metadata_filter, MetadataFilter)
-        and metadata_filter.operator
-        in {
-            MetadataOperator.NE,
-            MetadataOperator.NOT_IN,
-        }
+    if (
+        not (
+            source_storage_cls is Chroma
+            and isinstance(metadata_filter, MetadataFilter)
+            and metadata_filter.operator
+            in {
+                MetadataOperator.NE,
+                MetadataOperator.NOT_IN,
+            }
+        )
+        or chroma_override
     ):
         actual_idcs = sorted(map(int, (source.document_name for source in sources)))
         assert actual_idcs == expected_idcs
@@ -165,7 +174,9 @@ def test_chroma_ne_nin_non_existing_keys(
     tmp_local_root, metadata_filter, expected_idcs
 ):
     # See https://github.com/Quansight/ragna/issues/523 for details
-    test_smoke(tmp_local_root, Chroma, metadata_filter, expected_idcs)
+    test_smoke(
+        tmp_local_root, Chroma, metadata_filter, expected_idcs, chroma_override=True
+    )
 
 
 @pytest.mark.parametrize("source_storage_cls", [Chroma, LanceDB])

--- a/tests/source_storages/test_source_storages.py
+++ b/tests/source_storages/test_source_storages.py
@@ -100,8 +100,23 @@ metadata_filters = pytest.mark.parametrize(
 )
 
 
+@pytest.fixture
+def _xfail_chroma_ne_nin(request):
+    fixture_values = frozenset(request.node.callspec._idlist)
+
+    xfail_filters = {
+        frozenset(("Chroma", "or-nested")),
+        frozenset(("Chroma", "ne")),
+        frozenset(("Chroma", "not_in")),
+    }
+
+    if fixture_values in xfail_filters:
+        request.node.add_marker(pytest.mark.xfail())
+
+
 @metadata_filters
 @pytest.mark.parametrize("source_storage_cls", [Chroma])  # LanceDB
+@pytest.mark.usefixtures("_xfail_chroma_ne_nin")
 def test_smoke(tmp_local_root, source_storage_cls, metadata_filter, expected_idcs):
     document_root = tmp_local_root / "documents"
     document_root.mkdir()

--- a/tests/source_storages/test_source_storages.py
+++ b/tests/source_storages/test_source_storages.py
@@ -153,7 +153,7 @@ def test_smoke(tmp_local_root, source_storage_cls, metadata_filter, expected_idc
 
 
 @pytest.mark.parametrize(
-    "metadata_filter,expected_idcs",
+    ("metadata_filter", "expected_idcs"),
     [
         pytest.param(MetadataFilter.ne("key", "value"), [2, 3, 4, 5, 6], id="ne"),
         pytest.param(
@@ -161,7 +161,10 @@ def test_smoke(tmp_local_root, source_storage_cls, metadata_filter, expected_idc
         ),
     ],
 )
-def test_smoke_chroma_ne_nin(tmp_local_root, metadata_filter, expected_idcs):
+def test_chroma_ne_nin_non_existing_keys(
+    tmp_local_root, metadata_filter, expected_idcs
+):
+    # See https://github.com/Quansight/ragna/issues/523 for details
     test_smoke(tmp_local_root, Chroma, metadata_filter, expected_idcs)
 
 


### PR DESCRIPTION
This partially addresses #523 by updating the ChromaDB version to the latest 0.6.1 and patching particular test cases where ChromaDB's behavior differs from other databases.