### PR TITLE
Fix non-editable install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ all = [
 [tool.setuptools_scm]
 write_to = "ragna/_version.py"
 version_scheme = "release-branch-semver"
-local_scheme = "node-and-timestamp"
+local_scheme = "node-and-date"
 
 [project.scripts]
 ragna = "ragna.__main__:app"


### PR DESCRIPTION
This fixes #529 by changing the naming scheme for wheels created for non-editable installation