### PR TITLE
[FIX] Remove `defaults` channel from Conda environments in CI

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -18,7 +18,7 @@ runs:
       with:
         miniforge-version: latest
         activate-environment: ragna-dev
-        conda-remove-defaults: "true"
+        conda-remove-defaults: true
 
     - name: Display conda info
       shell: bash -elo pipefail {0}

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -18,6 +18,7 @@ runs:
       with:
         miniforge-version: latest
         activate-environment: ragna-dev
+        conda-remove-defaults: "true"
 
     - name: Display conda info
       shell: bash -elo pipefail {0}


### PR DESCRIPTION
This resolves #543 by explicitly removing the implicitly used `defaults` Conda channel.

See [the documentation for the GitHub action](https://github.com/conda-incubator/setup-miniconda?tab=readme-ov-file#example-14-remove-defaults-channel) for reference.