### PR TITLE
[ENH] Add `GET` endpoints for documents

### DIFF
--- a/ragna/core/_document.py
+++ b/ragna/core/_document.py
@@ -83,8 +83,11 @@ class LocalDocument(Document):
         name: str,
         metadata: dict[str, Any],
         handler: Optional[DocumentHandler] = None,
+        mime_type: str | None = None,
     ):
-        super().__init__(id=id, name=name, metadata=metadata, handler=handler)
+        super().__init__(
+            id=id, name=name, metadata=metadata, handler=handler, mime_type=mime_type
+        )
         if "path" not in self.metadata:
             metadata["path"] = str(ragna.local_root() / "documents" / str(self.id))
 

--- a/ragna/core/_document.py
+++ b/ragna/core/_document.py
@@ -34,7 +34,7 @@ class Document(RequirementsMixin, abc.ABC):
         self.handler = handler or self.get_handler(name)
         self.mime_type = (
             mime_type
-            or next(iter(mimetypes.guess_type(Path(name))))
+            or next(iter(mimetypes.guess_type(name)))
             or "application/octet-stream"
         )
 

--- a/ragna/core/_document.py
+++ b/ragna/core/_document.py
@@ -33,9 +33,7 @@ class Document(RequirementsMixin, abc.ABC):
         self.metadata = metadata
         self.handler = handler or self.get_handler(name)
         self.mime_type = (
-            mime_type
-            or next(iter(mimetypes.guess_type(name)))
-            or "application/octet-stream"
+            mime_type or mimetypes.guess_type(name)[0] or "application/octet-stream"
         )
 
     @staticmethod

--- a/ragna/deploy/_api.py
+++ b/ragna/deploy/_api.py
@@ -43,17 +43,17 @@ def make_router(engine: Engine) -> APIRouter:
 
     @router.get("/documents")
     async def get_documents(user: UserDependency) -> list[schemas.Document]:
-        return engine.get_documents(user.name)
+        return engine.get_documents(user=user.name)
 
     @router.get("/documents/{id}")
     async def get_document(user: UserDependency, id: uuid.UUID) -> schemas.Document:
-        return engine.get_document(user.name, id)
+        return engine.get_document(user=user.name, id=id)
 
     @router.get("/documents/{id}/content")
     async def get_document_content(
         user: UserDependency, id: uuid.UUID
     ) -> StreamingResponse:
-        schema_document = engine.get_document(user.name, id)
+        schema_document = engine.get_document(user=user.name, id=id)
         core_document = engine._to_core.document(schema_document)
         headers = {"Content-Disposition": f"inline; filename={schema_document.name}"}
 

--- a/ragna/deploy/_api.py
+++ b/ragna/deploy/_api.py
@@ -46,7 +46,7 @@ def make_router(engine: Engine) -> APIRouter:
 
     @router.get("/documents/{id}")
     async def get_document(user: UserDependency, id: uuid.UUID) -> schemas.Document:
-        return next(iter(engine.get_documents(user.name, [id])))
+        return engine.get_document(user.name, id)
 
     @router.get("/components")
     def get_components() -> schemas.Components:

--- a/ragna/deploy/_api.py
+++ b/ragna/deploy/_api.py
@@ -44,6 +44,10 @@ def make_router(engine: Engine) -> APIRouter:
     async def get_documents(user: UserDependency) -> list[schemas.Document]:
         return engine.get_documents(user.name)
 
+    @router.get("/documents/{id}")
+    async def get_document(user: UserDependency, id: uuid.UUID) -> schemas.Document:
+        return next(iter(engine.get_documents(user.name, [id])))
+
     @router.get("/components")
     def get_components() -> schemas.Components:
         return engine.get_components()

--- a/ragna/deploy/_api.py
+++ b/ragna/deploy/_api.py
@@ -54,7 +54,7 @@ def make_router(engine: Engine) -> APIRouter:
         user: UserDependency, id: uuid.UUID
     ) -> StreamingResponse:
         schema_document = engine.get_document(user.name, id)
-        core_document = engine._to_core(schema_document)
+        core_document = engine._to_core.document(schema_document)
         headers = {"Content-Disposition": f"inline; filename={schema_document.name}"}
 
         return StreamingResponse(

--- a/ragna/deploy/_api.py
+++ b/ragna/deploy/_api.py
@@ -40,6 +40,10 @@ def make_router(engine: Engine) -> APIRouter:
             ],
         )
 
+    @router.get("/documents")
+    async def get_documents(user: UserDependency) -> list[schemas.Document]:
+        return engine.get_documents(user.name)
+
     @router.get("/components")
     def get_components() -> schemas.Components:
         return engine.get_components()

--- a/ragna/deploy/_database.py
+++ b/ragna/deploy/_database.py
@@ -136,15 +136,11 @@ class Database:
     ) -> list[orm.Document]:
         # FIXME also check if the user is allowed to access the documents
         # FIXME: maybe just take the user id to avoid getting it twice in add_chat?
-        documents = (
-            session.execute(
-                select(orm.Document).where(orm.Document.id.in_(ids))
-                if ids is not None
-                else select(orm.Document)
-            )
-            .scalars()
-            .all()
-        )
+        expr = select(orm.Document)
+        expr = expr if ids is None else expr.where(orm.Document.id.in_(ids))
+
+        documents = session.execute(expr).scalars().all()
+
         if (ids is not None) and (len(documents) != len(ids)):
             raise RagnaException(
                 str(set(ids) - {document.id for document in documents})

--- a/ragna/deploy/_database.py
+++ b/ragna/deploy/_database.py
@@ -292,6 +292,7 @@ class SchemaToOrmConverter:
             user_id=user_id,
             name=document.name,
             metadata_=document.metadata,
+            mime_type=document.mime_type,
         )
 
     def source(self, source: schemas.Source) -> orm.Source:
@@ -358,7 +359,10 @@ class OrmToSchemaConverter:
 
     def document(self, document: orm.Document) -> schemas.Document:
         return schemas.Document(
-            id=document.id, name=document.name, metadata=document.metadata_
+            id=document.id,
+            name=document.name,
+            metadata=document.metadata_,
+            mime_type=document.mime_type,
         )
 
     def source(self, source: orm.Source) -> schemas.Source:

--- a/ragna/deploy/_database.py
+++ b/ragna/deploy/_database.py
@@ -137,8 +137,8 @@ class Database:
         # FIXME also check if the user is allowed to access the documents
         # FIXME: maybe just take the user id to avoid getting it twice in add_chat?
         expr = select(orm.Document)
-        expr = expr if ids is None else expr.where(orm.Document.id.in_(ids))
-
+        if ids is not None:
+            expr = expr.where(orm.Document.id.in_(ids))
         documents = session.execute(expr).scalars().all()
 
         if (ids is not None) and (len(documents) != len(ids)):

--- a/ragna/deploy/_database.py
+++ b/ragna/deploy/_database.py
@@ -137,13 +137,13 @@ class Database:
         # FIXME also check if the user is allowed to access the documents
         # FIXME: maybe just take the user id to avoid getting it twice in add_chat?
         documents = (
-            (
-                session.execute(select(orm.Document).where(orm.Document.id.in_(ids)))
-                .scalars()
-                .all()
+            session.execute(
+                select(orm.Document).where(orm.Document.id.in_(ids))
+                if ids is not None
+                else select(orm.Document)
             )
-            if ids is not None
-            else session.execute(select(orm.Document)).scalars().all()
+            .scalars()
+            .all()
         )
         if (ids is not None) and (len(documents) != len(ids)):
             raise RagnaException(

--- a/ragna/deploy/_engine.py
+++ b/ragna/deploy/_engine.py
@@ -197,7 +197,7 @@ class Engine:
             return self._database.get_documents(session, user=user, ids=ids)
 
     def get_document(self, *, user: str, id: uuid.UUID) -> schemas.Document:
-        return next(iter(self.get_documents(user=user, ids=[id])))
+        return self.get_documents(user=user, ids=[id])[0]
 
     def create_chat(
         self, *, user: str, chat_creation: schemas.ChatCreation

--- a/ragna/deploy/_engine.py
+++ b/ragna/deploy/_engine.py
@@ -182,7 +182,7 @@ class Engine:
 
         streams = dict(ids_and_streams)
 
-        documents = self.get_documents(user, streams.keys())
+        documents = self.get_documents(user=user, ids=streams.keys())
 
         for document in documents:
             core_document = cast(
@@ -191,13 +191,13 @@ class Engine:
             await core_document._write(streams[document.id])
 
     def get_documents(
-        self, user: str, ids: Collection[uuid.UUID] | None = None
+        self, *, user: str, ids: Collection[uuid.UUID] | None = None
     ) -> list[schemas.Document]:
         with self._database.get_session() as session:
             return self._database.get_documents(session, user=user, ids=ids)
 
-    def get_document(self, user: str, id: uuid.UUID) -> schemas.Document:
-        return next(iter(self.get_documents(user, [id])))
+    def get_document(self, *, user: str, id: uuid.UUID) -> schemas.Document:
+        return next(iter(self.get_documents(user=user, ids=[id])))
 
     def create_chat(
         self, *, user: str, chat_creation: schemas.ChatCreation

--- a/ragna/deploy/_engine.py
+++ b/ragna/deploy/_engine.py
@@ -190,7 +190,9 @@ class Engine:
             )
             await core_document._write(streams[document.id])
 
-    def get_documents(self, user: str, ids: Collection[uuid.UUID] | None = None):
+    def get_documents(
+        self, user: str, ids: Collection[uuid.UUID] | None = None
+    ) -> list[schemas.Document]:
         with self._database.get_session() as session:
             documents = self._database.get_documents(session, user=user, ids=ids)
 

--- a/ragna/deploy/_engine.py
+++ b/ragna/deploy/_engine.py
@@ -156,7 +156,9 @@ class Engine:
         # We create core.Document's first, because they might update the metadata
         core_documents = [
             self._config.document(
-                name=registration.name, metadata=registration.metadata
+                name=registration.name,
+                metadata=registration.metadata,
+                mime_type=registration.mime_type,
             )
             for registration in document_registrations
         ]

--- a/ragna/deploy/_engine.py
+++ b/ragna/deploy/_engine.py
@@ -288,6 +288,7 @@ class SchemaToCoreConverter:
             id=document.id,
             name=document.name,
             metadata=document.metadata,
+            mime_type=document.mime_type,
         )
 
     def source(self, source: schemas.Source) -> core.Source:
@@ -336,6 +337,7 @@ class CoreToSchemaConverter:
             id=document.id,
             name=document.name,
             metadata=document.metadata,
+            mime_type=document.mime_type,
         )
 
     def source(self, source: core.Source) -> schemas.Source:

--- a/ragna/deploy/_engine.py
+++ b/ragna/deploy/_engine.py
@@ -194,9 +194,7 @@ class Engine:
         self, user: str, ids: Collection[uuid.UUID] | None = None
     ) -> list[schemas.Document]:
         with self._database.get_session() as session:
-            documents = self._database.get_documents(session, user=user, ids=ids)
-
-        return documents
+            return self._database.get_documents(session, user=user, ids=ids)
 
     def get_document(self, user: str, id: uuid.UUID) -> schemas.Document:
         return next(iter(self.get_documents(user, [id])))

--- a/ragna/deploy/_engine.py
+++ b/ragna/deploy/_engine.py
@@ -198,6 +198,9 @@ class Engine:
 
         return documents
 
+    def get_document(self, user: str, id: uuid.UUID) -> schemas.Document:
+        return next(iter(self.get_documents(user, [id])))
+
     def create_chat(
         self, *, user: str, chat_creation: schemas.ChatCreation
     ) -> schemas.Chat:

--- a/ragna/deploy/_orm.py
+++ b/ragna/deploy/_orm.py
@@ -103,6 +103,7 @@ class Document(Base):
     # Mind the trailing underscore here. Unfortunately, this is necessary, because
     # metadata without the underscore is reserved by SQLAlchemy
     metadata_ = Column(Json, nullable=False)
+    mime_type = Column(types.String, nullable=False)
     chats = relationship(
         "Chat",
         secondary=document_chat_association_table,

--- a/ragna/deploy/_schemas.py
+++ b/ragna/deploy/_schemas.py
@@ -78,6 +78,7 @@ class Components(BaseModel):
 class DocumentRegistration(BaseModel):
     name: str
     metadata: dict[str, Any] = Field(default_factory=dict)
+    mime_type: str | None = None
 
 
 class Document(BaseModel):

--- a/ragna/deploy/_schemas.py
+++ b/ragna/deploy/_schemas.py
@@ -84,6 +84,7 @@ class Document(BaseModel):
     id: uuid.UUID = Field(default_factory=uuid.uuid4)
     name: str
     metadata: dict[str, Any]
+    mime_type: str
 
 
 class Source(BaseModel):

--- a/tests/deploy/api/test_components.py
+++ b/tests/deploy/api/test_components.py
@@ -51,8 +51,8 @@ def test_unknown_component(tmp_local_root):
     config = Config(local_root=tmp_local_root)
 
     document_root = config.local_root / "documents"
-    document_root.mkdir()
-    document_path = document_root / "test.txt"
+    document_root.mkdir(exist_ok=True)
+    document_path = document_root / "test_unknown_component.txt"
     with open(document_path, "w") as file:
         file.write("!\n")
 

--- a/tests/deploy/api/test_components.py
+++ b/tests/deploy/api/test_components.py
@@ -57,9 +57,7 @@ def test_unknown_component(tmp_local_root):
     with open(document_path, "w") as file:
         file.write("!\n")
 
-    with make_api_client(
-        config=Config(), ignore_unavailable_components=False
-    ) as client:
+    with make_api_client(config=config, ignore_unavailable_components=False) as client:
         document = upload_documents(client=client, document_paths=[document_path])[0]
 
         response = client.post(

--- a/tests/deploy/api/test_components.py
+++ b/tests/deploy/api/test_components.py
@@ -51,8 +51,8 @@ def test_unknown_component(tmp_local_root):
     config = Config(local_root=tmp_local_root)
 
     document_root = config.local_root / "documents"
-    document_root.mkdir(exist_ok=True)
-    document_path = document_root / "test_unknown_component.txt"
+    document_root.mkdir()
+    document_path = document_root / "test.txt"
     with open(document_path, "w") as file:
         file.write("!\n")
 

--- a/tests/deploy/api/test_endpoints.py
+++ b/tests/deploy/api/test_endpoints.py
@@ -19,9 +19,7 @@ def test_get_documents(tmp_local_root):
         with open(document_path, "w") as file:
             file.write(content)
 
-    with make_api_client(
-        config=Config(), ignore_unavailable_components=False
-    ) as client:
+    with make_api_client(config=config, ignore_unavailable_components=False) as client:
         documents = upload_documents(client=client, document_paths=document_paths)
         response = client.get("/api/documents").raise_for_status()
 
@@ -43,9 +41,7 @@ def test_get_document(tmp_local_root):
     with open(document_path, "w") as file:
         file.write(_document_content_text[0])
 
-    with make_api_client(
-        config=Config(), ignore_unavailable_components=False
-    ) as client:
+    with make_api_client(config=config, ignore_unavailable_components=False) as client:
         document = upload_documents(client=client, document_paths=[document_path])[0]
         response = client.get(f"/api/documents/{document['id']}").raise_for_status()
 
@@ -62,9 +58,7 @@ def test_get_document_content(tmp_local_root):
     with open(document_path, "w") as file:
         file.write(document_content)
 
-    with make_api_client(
-        config=Config(), ignore_unavailable_components=False
-    ) as client:
+    with make_api_client(config=config, ignore_unavailable_components=False) as client:
         document = upload_documents(client=client, document_paths=[document_path])[0]
 
         with client.stream(

--- a/tests/deploy/api/test_endpoints.py
+++ b/tests/deploy/api/test_endpoints.py
@@ -46,11 +46,11 @@ def test_get_documents(tmp_local_root):
         response = client.get("/api/documents").raise_for_status()
 
         # Sort the items in case they are retrieved in different orders
-        def _sorting_key(d):
+        def sorting_key(d):
             return d["id"]
 
-        assert sorted(documents, key=_sorting_key) == sorted(
-            response.json(), key=_sorting_key
+        assert sorted(documents, key=sorting_key) == sorted(
+            response.json(), key=sorting_key
         )
 
 

--- a/tests/deploy/api/test_endpoints.py
+++ b/tests/deploy/api/test_endpoints.py
@@ -11,7 +11,7 @@ _document_content_text = [
 ]
 
 
-@pytest.mark.parametrize(
+mime_types = pytest.mark.parametrize(
     ("mime_type",),
     [
         (None,),  # Let the mimetypes library decide
@@ -19,6 +19,9 @@ _document_content_text = [
         ("application/pdf",),
     ],
 )
+
+
+@mime_types
 def test_get_documents(tmp_local_root, mime_type):
     config = Config(local_root=tmp_local_root)
 

--- a/tests/deploy/api/test_endpoints.py
+++ b/tests/deploy/api/test_endpoints.py
@@ -117,9 +117,9 @@ def test_get_document_content(tmp_local_root, mime_type):
             "GET", f"/api/documents/{document['id']}/content"
         ) as response:
             response_mime_type = response.headers["content-type"].split(";")[0]
-            received_lines = list(response.iter_lines())
+            received_text = response.read().decode("utf-8")
 
-    assert received_lines == [document_content.replace("\n", "")]
+    assert received_text == document_content
 
     assert (
         document["mime_type"]

--- a/tests/deploy/api/test_endpoints.py
+++ b/tests/deploy/api/test_endpoints.py
@@ -2,19 +2,22 @@ from ragna.deploy import Config
 from tests.deploy.api.utils import upload_documents
 from tests.deploy.utils import make_api_client
 
+_document_content_text = [
+    f"Needs more {needs_more_of}\n" for needs_more_of in ["reverb", "cowbell"]
+]
+
 
 def test_get_documents(tmp_local_root):
     config = Config(local_root=tmp_local_root)
-    needs_more_of = ["reverb", "cowbell"]
 
     document_root = config.local_root / "documents"
     document_root.mkdir()
     document_paths = [
-        document_root / f"test{counter}.txt" for counter in range(len(needs_more_of))
+        document_root / f"test{idx}.txt" for idx in range(len(_document_content_text))
     ]
-    for what_it_needs, document_path in zip(needs_more_of, document_paths):
+    for content, document_path in zip(_document_content_text, document_paths):
         with open(document_path, "w") as file:
-            file.write(f"Needs more {what_it_needs}\n")
+            file.write(content)
 
     with make_api_client(
         config=Config(), ignore_unavailable_components=False
@@ -38,7 +41,7 @@ def test_get_document(tmp_local_root):
     document_root.mkdir()
     document_path = document_root / "test.txt"
     with open(document_path, "w") as file:
-        file.write("Needs more reverb\n")
+        file.write(_document_content_text[0])
 
     with make_api_client(
         config=Config(), ignore_unavailable_components=False
@@ -55,8 +58,9 @@ def test_get_document_content(tmp_local_root):
     document_root = config.local_root / "documents"
     document_root.mkdir()
     document_path = document_root / "test.txt"
+    document_content = _document_content_text[0]
     with open(document_path, "w") as file:
-        file.write("Needs more reverb\n")
+        file.write(document_content)
 
     with make_api_client(
         config=Config(), ignore_unavailable_components=False
@@ -68,4 +72,4 @@ def test_get_document_content(tmp_local_root):
         ) as response:
             received_lines = list(response.iter_lines())
 
-    assert received_lines == ["Needs more reverb"]
+    assert received_lines == [document_content.replace("\n", "")]

--- a/tests/deploy/api/test_endpoints.py
+++ b/tests/deploy/api/test_endpoints.py
@@ -38,12 +38,10 @@ def test_get_documents(tmp_local_root):
             ]
             client.put(
                 "/api/documents",
-                files={
-                    "documents": [
-                        (document["id"], file)
-                        for document, file in zip(documents, files)
-                    ]
-                },
+                files=[
+                    ("documents", (document["id"], file))
+                    for document, file in zip(documents, files)
+                ],
             )
 
         response = client.get("/api/documents")
@@ -82,7 +80,7 @@ def test_get_document(tmp_local_root):
         with open(document_path, "rb") as file:
             client.put(
                 "/api/documents",
-                files={"documents": [(document["id"], file)]},
+                files=[("documents", (document["id"], file))],
             )
 
         response = client.get(f"/api/documents/{document['id']}")

--- a/tests/deploy/api/test_endpoints.py
+++ b/tests/deploy/api/test_endpoints.py
@@ -94,9 +94,9 @@ def test_get_document_content(tmp_local_root, mime_type):
             "GET", f"/api/documents/{document['id']}/content"
         ) as response:
             response_mime_type = response.headers["content-type"].split(";")[0]
-            received_text = response.read().decode("utf-8")
+            received_bytes = response.read()
 
-    assert received_text == document_content
+    assert received_bytes == document_content.encode("utf-8")
 
     assert (
         document["mime_type"]

--- a/tests/deploy/api/test_endpoints.py
+++ b/tests/deploy/api/test_endpoints.py
@@ -44,8 +44,7 @@ def test_get_documents(tmp_local_root):
                 ],
             )
 
-        response = client.get("/api/documents")
-        response.raise_for_status()
+        response = client.get("/api/documents").raise_for_status()
 
         # Sort the items in case they are retrieved in different orders
         def _sorting_key(d):
@@ -83,8 +82,7 @@ def test_get_document(tmp_local_root):
                 files=[("documents", (document["id"], file))],
             )
 
-        response = client.get(f"/api/documents/{document['id']}")
-        response.raise_for_status()
+        response = client.get(f"/api/documents/{document['id']}").raise_for_status()
 
         assert document == response.json()
 

--- a/tests/deploy/api/test_endpoints.py
+++ b/tests/deploy/api/test_endpoints.py
@@ -1,0 +1,58 @@
+import contextlib
+
+from ragna.deploy import Config
+from tests.deploy.utils import make_api_client
+
+
+def test_get_documents(tmp_local_root):
+    config = Config(local_root=tmp_local_root)
+
+    needs_more_of = ["reverb", "cowbell"]
+
+    document_root = config.local_root / "documents"
+    document_root.mkdir(exist_ok=True)
+    document_paths = [
+        document_root / f"test_get_documents_{what_it_needs}.txt"
+        for what_it_needs in needs_more_of
+    ]
+    for what_it_needs, document_path in zip(needs_more_of, document_paths):
+        with open(document_path, "w") as file:
+            file.write(f"Needs more {what_it_needs}\n")
+
+    with make_api_client(
+        config=Config(), ignore_unavailable_components=False
+    ) as client:
+        documents = (
+            client.post(
+                "/api/documents",
+                json=[{"name": document_path.name} for document_path in document_paths],
+            )
+            .raise_for_status()
+            .json()
+        )
+
+        with contextlib.ExitStack() as stack:
+            files = [
+                stack.enter_context(open(document_path, "rb"))
+                for document_path in document_paths
+            ]
+            client.put(
+                "/api/documents",
+                files={
+                    "documents": [
+                        (document["id"], file)
+                        for document, file in zip(documents, files)
+                    ]
+                },
+            )
+
+        response = client.get("/api/documents")
+        response.raise_for_status()
+
+        # Sort the items in case they are retrieved in different orders
+        def _sorting_key(d):
+            return d["id"]
+
+        assert sorted(documents, key=_sorting_key) == sorted(
+            response.json(), key=_sorting_key
+        )

--- a/tests/deploy/api/test_endpoints.py
+++ b/tests/deploy/api/test_endpoints.py
@@ -1,12 +1,10 @@
-import contextlib
-
 from ragna.deploy import Config
+from tests.deploy.api.utils import upload_documents
 from tests.deploy.utils import make_api_client
 
 
 def test_get_documents(tmp_local_root):
     config = Config(local_root=tmp_local_root)
-
     needs_more_of = ["reverb", "cowbell"]
 
     document_root = config.local_root / "documents"
@@ -21,37 +19,16 @@ def test_get_documents(tmp_local_root):
     with make_api_client(
         config=Config(), ignore_unavailable_components=False
     ) as client:
-        documents = (
-            client.post(
-                "/api/documents",
-                json=[{"name": document_path.name} for document_path in document_paths],
-            )
-            .raise_for_status()
-            .json()
-        )
-
-        with contextlib.ExitStack() as stack:
-            files = [
-                stack.enter_context(open(document_path, "rb"))
-                for document_path in document_paths
-            ]
-            client.put(
-                "/api/documents",
-                files=[
-                    ("documents", (document["id"], file))
-                    for document, file in zip(documents, files)
-                ],
-            )
-
+        documents = upload_documents(client=client, document_paths=document_paths)
         response = client.get("/api/documents").raise_for_status()
 
-        # Sort the items in case they are retrieved in different orders
-        def sorting_key(d):
-            return d["id"]
+    # Sort the items in case they are retrieved in different orders
+    def sorting_key(d):
+        return d["id"]
 
-        assert sorted(documents, key=sorting_key) == sorted(
-            response.json(), key=sorting_key
-        )
+    assert sorted(documents, key=sorting_key) == sorted(
+        response.json(), key=sorting_key
+    )
 
 
 def test_get_document(tmp_local_root):
@@ -66,24 +43,10 @@ def test_get_document(tmp_local_root):
     with make_api_client(
         config=Config(), ignore_unavailable_components=False
     ) as client:
-        document = (
-            client.post(
-                "/api/documents",
-                json=[{"name": document_path.name}],
-            )
-            .raise_for_status()
-            .json()[0]
-        )
-
-        with open(document_path, "rb") as file:
-            client.put(
-                "/api/documents",
-                files=[("documents", (document["id"], file))],
-            )
-
+        document = upload_documents(client=client, document_paths=[document_path])[0]
         response = client.get(f"/api/documents/{document['id']}").raise_for_status()
 
-        assert document == response.json()
+    assert document == response.json()
 
 
 def test_get_document_content(tmp_local_root):
@@ -98,24 +61,11 @@ def test_get_document_content(tmp_local_root):
     with make_api_client(
         config=Config(), ignore_unavailable_components=False
     ) as client:
-        document = (
-            client.post(
-                "/api/documents",
-                json=[{"name": document_path.name}],
-            )
-            .raise_for_status()
-            .json()[0]
-        )
-
-        with open(document_path, "rb") as file:
-            client.put(
-                "/api/documents",
-                files=[("documents", (document["id"], file))],
-            )
+        document = upload_documents(client=client, document_paths=[document_path])[0]
 
         with client.stream(
             "GET", f"/api/documents/{document['id']}/content"
         ) as response:
             received_lines = list(response.iter_lines())
 
-        assert received_lines == ["Needs more reverb"]
+    assert received_lines == ["Needs more reverb"]

--- a/tests/deploy/api/test_endpoints.py
+++ b/tests/deploy/api/test_endpoints.py
@@ -56,3 +56,36 @@ def test_get_documents(tmp_local_root):
         assert sorted(documents, key=_sorting_key) == sorted(
             response.json(), key=_sorting_key
         )
+
+
+def test_get_document(tmp_local_root):
+    config = Config(local_root=tmp_local_root)
+
+    document_root = config.local_root / "documents"
+    document_root.mkdir(exist_ok=True)
+    document_path = document_root / "test_get_document.txt"
+    with open(document_path, "w") as file:
+        file.write("Needs more reverb\n")
+
+    with make_api_client(
+        config=Config(), ignore_unavailable_components=False
+    ) as client:
+        document = (
+            client.post(
+                "/api/documents",
+                json=[{"name": document_path.name}],
+            )
+            .raise_for_status()
+            .json()[0]
+        )
+
+        with open(document_path, "rb") as file:
+            client.put(
+                "/api/documents",
+                files={"documents": [(document["id"], file)]},
+            )
+
+        response = client.get(f"/api/documents/{document['id']}")
+        response.raise_for_status()
+
+        assert document == response.json()

--- a/tests/deploy/api/test_endpoints.py
+++ b/tests/deploy/api/test_endpoints.py
@@ -10,10 +10,9 @@ def test_get_documents(tmp_local_root):
     needs_more_of = ["reverb", "cowbell"]
 
     document_root = config.local_root / "documents"
-    document_root.mkdir(exist_ok=True)
+    document_root.mkdir()
     document_paths = [
-        document_root / f"test_get_documents_{what_it_needs}.txt"
-        for what_it_needs in needs_more_of
+        document_root / f"test{counter}.txt" for counter in range(len(needs_more_of))
     ]
     for what_it_needs, document_path in zip(needs_more_of, document_paths):
         with open(document_path, "w") as file:
@@ -59,8 +58,8 @@ def test_get_document(tmp_local_root):
     config = Config(local_root=tmp_local_root)
 
     document_root = config.local_root / "documents"
-    document_root.mkdir(exist_ok=True)
-    document_path = document_root / "test_get_document.txt"
+    document_root.mkdir()
+    document_path = document_root / "test.txt"
     with open(document_path, "w") as file:
         file.write("Needs more reverb\n")
 
@@ -91,8 +90,8 @@ def test_get_document_content(tmp_local_root):
     config = Config(local_root=tmp_local_root)
 
     document_root = config.local_root / "documents"
-    document_root.mkdir(exist_ok=True)
-    document_path = document_root / "test_get_document_content.txt"
+    document_root.mkdir()
+    document_path = document_root / "test.txt"
     with open(document_path, "w") as file:
         file.write("Needs more reverb\n")
 

--- a/tests/deploy/api/test_endpoints.py
+++ b/tests/deploy/api/test_endpoints.py
@@ -50,14 +50,6 @@ def test_get_documents(tmp_local_root, mime_type):
         response.json(), key=sorting_key
     )
 
-    # Assert that the correct MIME types are returned
-    for antwort in response.json():
-        assert antwort["mime_type"] == (
-            mime_type
-            if mime_type is not None
-            else mimetypes.guess_type(document_path.name)[0]
-        )
-
 
 @mime_types
 def test_get_document(tmp_local_root, mime_type):
@@ -78,13 +70,6 @@ def test_get_document(tmp_local_root, mime_type):
         response = client.get(f"/api/documents/{document['id']}").raise_for_status()
 
     assert document == response.json()
-
-    # Assert that the correct MIME type is returned
-    assert response.json()["mime_type"] == (
-        mime_type
-        if mime_type is not None
-        else mimetypes.guess_type(document_path.name)[0]
-    )
 
 
 @mime_types

--- a/tests/deploy/api/test_endpoints.py
+++ b/tests/deploy/api/test_endpoints.py
@@ -94,9 +94,9 @@ def test_get_document_content(tmp_local_root, mime_type):
             "GET", f"/api/documents/{document['id']}/content"
         ) as response:
             response_mime_type = response.headers["content-type"].split(";")[0]
-            received_bytes = response.read()
+            received_lines = list(response.iter_lines())
 
-    assert received_bytes == document_content.encode("utf-8")
+    assert received_lines == [document_content.replace("\n", "")]
 
     assert (
         document["mime_type"]

--- a/tests/deploy/api/test_endpoints.py
+++ b/tests/deploy/api/test_endpoints.py
@@ -50,17 +50,12 @@ def test_get_documents(tmp_local_root, mime_type):
         response.json(), key=sorting_key
     )
 
-    for document, antwort in zip(
-        sorted(documents, key=sorting_key), sorted(response.json(), key=sorting_key)
-    ):
-        assert (
-            document["mime_type"]
-            == antwort["mime_type"]
-            == (
-                mime_type
-                if mime_type is not None
-                else mimetypes.guess_type(document_path.name)[0]
-            )
+    # Assert that the correct MIME types are returned
+    for antwort in response.json():
+        assert antwort["mime_type"] == (
+            mime_type
+            if mime_type is not None
+            else mimetypes.guess_type(document_path.name)[0]
         )
 
 
@@ -84,14 +79,11 @@ def test_get_document(tmp_local_root, mime_type):
 
     assert document == response.json()
 
-    assert (
-        document["mime_type"]
-        == response.json()["mime_type"]
-        == (
-            mime_type
-            if mime_type is not None
-            else mimetypes.guess_type(document_path.name)[0]
-        )
+    # Assert that the correct MIME type is returned
+    assert response.json()["mime_type"] == (
+        mime_type
+        if mime_type is not None
+        else mimetypes.guess_type(document_path.name)[0]
     )
 
 

--- a/tests/deploy/api/utils.py
+++ b/tests/deploy/api/utils.py
@@ -4,6 +4,8 @@ import contextlib
 def upload_documents(*, client, document_paths, mime_types=None):
     if mime_types is None:
         mime_types = [None for _ in document_paths]
+    else:
+        assert len(mime_types) == len(document_paths)
     documents = (
         client.post(
             "/api/documents",
@@ -12,11 +14,7 @@ def upload_documents(*, client, document_paths, mime_types=None):
                     "name": document_path.name,
                     "mime_type": mime_type,
                 }
-                for document_path, mime_type in zip(
-                    document_paths,
-                    mime_types,
-                    strict=True,
-                )
+                for document_path, mime_type in zip(document_paths, mime_types)
             ],
         )
         .raise_for_status()

--- a/tests/deploy/api/utils.py
+++ b/tests/deploy/api/utils.py
@@ -1,0 +1,27 @@
+import contextlib
+
+
+def upload_documents(*, client, document_paths):
+    documents = (
+        client.post(
+            "/api/documents",
+            json=[{"name": document_path.name} for document_path in document_paths],
+        )
+        .raise_for_status()
+        .json()
+    )
+
+    with contextlib.ExitStack() as stack:
+        files = [
+            stack.enter_context(open(document_path, "rb"))
+            for document_path in document_paths
+        ]
+        client.put(
+            "/api/documents",
+            files=[
+                ("documents", (document["id"], file))
+                for document, file in zip(documents, files)
+            ],
+        )
+
+    return documents

--- a/tests/deploy/api/utils.py
+++ b/tests/deploy/api/utils.py
@@ -1,11 +1,19 @@
 import contextlib
 
 
-def upload_documents(*, client, document_paths):
+def upload_documents(*, client, document_paths, mime_types=None):
+    if mime_types is None:
+        mime_types = [None for _ in document_paths]
     documents = (
         client.post(
             "/api/documents",
-            json=[{"name": document_path.name} for document_path in document_paths],
+            json=[
+                {
+                    "name": document_path.name,
+                    "mime_type": mime_type,
+                }
+                for document_path, mime_type in zip(document_paths, mime_types)
+            ],
         )
         .raise_for_status()
         .json()

--- a/tests/deploy/api/utils.py
+++ b/tests/deploy/api/utils.py
@@ -12,7 +12,11 @@ def upload_documents(*, client, document_paths, mime_types=None):
                     "name": document_path.name,
                     "mime_type": mime_type,
                 }
-                for document_path, mime_type in zip(document_paths, mime_types)
+                for document_path, mime_type in zip(
+                    document_paths,
+                    mime_types,
+                    strict=True,
+                )
             ],
         )
         .raise_for_status()


### PR DESCRIPTION
This PR partially addresses #466 and supersedes certain respective parts of #486.

The new endpoints, all using the `GET` method, in this PR are as follow:

- `/documents`
- `/documents/{id}`
- `/documents/{id}/content`

Additionally, we now include MIME types in `ragna.core.Document`s.

A test utility `upload_documents` is also introduced for convenience when writing tests for endpoints.

Much of the code in this PR is copied from or inspired by @blakerosenthal's #486 