### PR TITLE
Allow `Assistant`s to specify their logos

### DIFF
--- a/ragna/core/_components.py
+++ b/ragna/core/_components.py
@@ -302,3 +302,8 @@ class Assistant(Component, abc.ABC):
             Answer.
         """
         ...
+
+    @property
+    def avatar(self) -> str:
+        """Return a default avatar for an assistant in a chat."""
+        return "imgs/ragna_logo.svg"


### PR DESCRIPTION
Adds an `avatar` property to the `Assistant` and integrates its use into the UI.