### PR TITLE
Add lines to git-related files for Pixi

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,5 @@
 *.png filter=lfs diff=lfs merge=lfs -text
 # but keep the brand images as regular images
 docs/assets/brand/logo-**/* !filter !diff !merge binary
+# SCM syntax highlighting & preventing 3-way merges
+pixi.lock merge=binary linguist-language=YAML linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,7 @@ cython_debug/
 
 # VSCode
 .vscode/
+
+# pixi environments
+.pixi
+*.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -171,4 +171,3 @@ cython_debug/
 
 # pixi environments
 .pixi
-*.egg-info


### PR DESCRIPTION
Add a few lines to `.gitignore` and `.gitattributes` for a better experience for developers of Ragna who are using [Pixi](https://pixi.sh/).