### PR TITLE
fix default factories in merge_models

### DIFF
--- a/ragna/core/_utils.py
+++ b/ragna/core/_utils.py
@@ -7,7 +7,7 @@ import importlib
 import importlib.metadata
 import os
 from collections import defaultdict
-from typing import Any, Callable, Collection, Optional, Type, Union, cast
+from typing import Any, Collection, Optional, Type, Union, cast
 
 import packaging.requirements
 import pydantic
@@ -133,9 +133,9 @@ def merge_models(
             if field.is_required():
                 default = ...
             elif field.default is pydantic_core.PydanticUndefined:
-                default = cast(Callable[[], Any], field.default_factory)()
+                default = ("default_factory", field.default_factory)
             else:
-                default = field.default
+                default = ("default", field.default)
 
             raw_field_definitions[name].append((type_, default))
 
@@ -149,14 +149,15 @@ def merge_models(
         type_ = types.pop()
 
         defaults = set(defaults)
-        if len(defaults) == 1:
-            default = defaults.pop()
-        elif ... in defaults:
-            default = ...
+        kwargs: dict[str, Any]
+        if ... in defaults:
+            kwargs = {}
+        elif len(defaults) == 1:
+            kwargs = dict(defaults)
         else:
-            default = None
+            kwargs = {"default": None}
 
-        field_definitions[name] = (type_, default)
+        field_definitions[name] = (type_, pydantic.Field(**kwargs))
 
     return cast(
         Type[pydantic.BaseModel],


### PR DESCRIPTION
This is needed for #560, where we add a `default_factory` that takes the formerly validated fields as input and thus cannot be invoked without them.

The only reason we have invoked the `default_factory` before this PR is to determine whether or not we have multiple default values. However, that reasoning is flawed in two ways:

1. An invocation of the `default_factory` only captures a snapshot. Meaning, even a simple `default_factory` that returns the current datetime, will produce two different results when called multiple times. Thus, although multiple models might use the same `default_factory`, it will not be propagated to the merged model.
2. Even if there is only a single `default_factory` for a given field, we are completely removing the dynamic element of the `default_factory` by turning it into a static default value.

This PR resolves both issues above by using the `default_factory` directly for determining whether there are multiple default values. In addition it also propagates the `default_factory` if there is only one such value.