### PR TITLE
Parallelize fetching metadata for Qdrant

### DIFF
--- a/ragna/source_storages/_qdrant.py
+++ b/ragna/source_storages/_qdrant.py
@@ -86,7 +86,7 @@ class Qdrant(VectorDatabaseSourceStorage):
 
     async def _fetch_metadata(self, *args: Any, **kwargs: Any):
         limit = kwargs.pop("limit", None)
-        _ = kwargs.pop("with_payload", None)
+        with_payload = kwargs.pop("with_payload", None)
 
         ids = []
         while True:
@@ -115,7 +115,7 @@ class Qdrant(VectorDatabaseSourceStorage):
                 *[
                     self._client.scroll(
                         *args,
-                        with_payload=True,
+                        with_payload=with_payload,
                         limit=limit,
                         offset=offset,
                         **kwargs,

--- a/ragna/source_storages/_qdrant.py
+++ b/ragna/source_storages/_qdrant.py
@@ -5,7 +5,7 @@ import itertools
 import os
 import uuid
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Optional, cast
+from typing import TYPE_CHECKING, Any, AsyncIterator, Optional, cast
 
 import ragna
 from ragna.core import (
@@ -86,7 +86,7 @@ class Qdrant(VectorDatabaseSourceStorage):
 
     async def _fetch_raw_metadata_entries(
         self, *, corpus_name: str
-    ) -> AsyncGenerator[dict[str, Any], None]:
+    ) -> AsyncIterator[dict[str, Any]]:
         ids: list[str] = []
         offset = None
         while True:

--- a/ragna/source_storages/_qdrant.py
+++ b/ragna/source_storages/_qdrant.py
@@ -84,7 +84,7 @@ class Qdrant(VectorDatabaseSourceStorage):
         elif non_existing_corpus:
             raise_non_existing_corpus(self, corpus_name)
 
-    async def _fetch_raw_metadata(
+    async def _fetch_raw_metadata_entries(
         self, *, corpus_name: str, limit: Optional[int] = None
     ) -> AsyncGenerator[dict[str, Any], None]:
         ids: list[str] = []
@@ -127,7 +127,7 @@ class Qdrant(VectorDatabaseSourceStorage):
 
     async def _fetch_metadata(self, corpus_name: str) -> dict[str, Any]:
         corpus_metadata = defaultdict(set)
-        async for point in self._fetch_raw_metadata(corpus_name=corpus_name):
+        async for point in self._fetch_raw_metadata_entries(corpus_name=corpus_name):
             for key, value in point.items():
                 if any(
                     [

--- a/ragna/source_storages/_qdrant.py
+++ b/ragna/source_storages/_qdrant.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import itertools
 import os
 import uuid
 from collections import defaultdict

--- a/ragna/source_storages/_qdrant.py
+++ b/ragna/source_storages/_qdrant.py
@@ -85,7 +85,7 @@ class Qdrant(VectorDatabaseSourceStorage):
             raise_non_existing_corpus(self, corpus_name)
 
     async def _fetch_raw_metadata_entries(
-        self, *, corpus_name: str, limit: Optional[int] = None
+        self, *, corpus_name: str
     ) -> AsyncGenerator[dict[str, Any], None]:
         ids: list[str] = []
         offset = None
@@ -107,7 +107,7 @@ class Qdrant(VectorDatabaseSourceStorage):
         # There is no way to know a priori the size of the metadata, so
         # we just limit ourselves to twenty requests to the database.
         # This can change in the future.
-        limit: int = limit if limit is not None else max(len(ids) // 20, 10)
+        limit: int = max(len(ids) // 20, 10)
 
         for payload in itertools.chain.from_iterable(
             (cast(dict[str, Any], record.payload) for record in records)

--- a/tests/source_storages/test_source_storages.py
+++ b/tests/source_storages/test_source_storages.py
@@ -312,7 +312,8 @@ async def test_list_metadata(tmp_local_root, cls):
     document_root.mkdir()
 
     documents = []
-    for idx in range(5):
+    num_documents = 36
+    for idx in range(num_documents):
         path = (document_root / f"document{idx}").with_suffix(
             random.choice([".txt", ".md"])
         )
@@ -322,9 +323,10 @@ async def test_list_metadata(tmp_local_root, cls):
             )
         documents.append(LocalDocument.from_path(path))
 
+    corpus_size = 12
     corpuses = {
-        "corpus0": documents[: len(documents) // 2],
-        "corpus1": documents[len(documents) // 2 :],
+        f"corpus{batch}": documents[batch * corpus_size : (batch + 1) * corpus_size]
+        for batch in range(num_documents // corpus_size)
     }
 
     source_storage = cls()


### PR DESCRIPTION
This PR parallelizes fetching metadata for Qdrant for performance purposes. It parallelizes both across corpuses, as well as across pages of metadata for a given corpus.

Tests are also modified so that test corpuses are large enough to necessarily require pagination.

#557 is addressed in the process of implementing the fetching of metadata for a given corpus.