### PR TITLE
Temporary fix for docker requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,15 @@ dependencies = [
     "fastapi",
     "httpx",
     "packaging",
-    "panel[fastapi]==1.5.4",
+    # Removing `panel[fastapi]` in favor of the below pinned `panel` and `bokeh-fastapi` dependencies
+    # is a temporary fix for https://github.com/Quansight/ragna/issues/565
+    # The problem is that ChromaDB hard pins `fastapi`, which then creates conflicts with `panel[fastapi]`.
+    # See https://github.com/chroma-core/chroma/issues/4243
+    # TODO: Revert this change by replacing the `panel` and `bokeh-fastapi` dependencies with the
+    # commented out `panel[fastapi]` dependency when ChromaDB fixes this issue.
+    # "panel[fastapi]==1.5.4",
+    "panel==1.5.4",
+    "bokeh-fastapi>=0.1.3",
     "pydantic>=2",
     "pydantic-core",
     "pydantic-settings>=2",


### PR DESCRIPTION
Temporarily change `panel[fastapi]` dependency to `panel` together with `bokeh-fastapi`

Temporarily fixes #565 