### PR TITLE
Run `update-docker-requirements.yml` on pull request for feedback

### DIFF
--- a/.github/workflows/update-docker-requirements.yml
+++ b/.github/workflows/update-docker-requirements.yml
@@ -8,6 +8,11 @@ on:
       - ".github/workflows/update-docker-requirements.yml"
       - "pyproject.toml"
       - "requirements-docker.lock"
+  pull_request:
+    paths:
+      - ".github/workflows/update-docker-requirements.yml"
+      - "pyproject.toml"
+      - "requirements-docker.lock"
 
 permissions:
   pull-requests: write
@@ -45,6 +50,7 @@ jobs:
           echo "needs-update=${NEEDS_UPDATE}" | tee --append $GITHUB_OUTPUT
 
       - name: Check if commit is associated with a PR
+        if: ${{ github.event_name != 'pull_request' }}
         id: pr-check
         env:
           GH_TOKEN: ${{ github.token }}
@@ -66,7 +72,7 @@ jobs:
           echo "merger=${MERGER}" | tee --append $GITHUB_OUTPUT
 
       - name: Open a PR to update the requirements
-        if: ${{ steps.update.outputs.needs-update }}
+        if: ${{ steps.update.outputs.needs-update && github.event_name != 'pull_request' }}
         uses: peter-evans/create-pull-request@v5
         with:
           commit-message: update requirements-docker.lock
@@ -81,7 +87,7 @@ jobs:
           reviewers: ${{ steps.pr-check.outputs.merger }}
 
       - name: Create failure issue
-        if: failure()
+        if: ${{ failure() && github.event_name != 'pull_request' }}
         uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/update-docker-requirements.yml
+++ b/.github/workflows/update-docker-requirements.yml
@@ -72,7 +72,9 @@ jobs:
           echo "merger=${MERGER}" | tee --append $GITHUB_OUTPUT
 
       - name: Open a PR to update the requirements
-        if: ${{ steps.update.outputs.needs-update && github.event_name != 'pull_request' }}
+        if:
+          ${{ steps.update.outputs.needs-update && github.event_name != 'pull_request'
+          }}
         uses: peter-evans/create-pull-request@v5
         with:
           commit-message: update requirements-docker.lock


### PR DESCRIPTION
Gives the developer feedback when making changes to dependencies so as not to break the generation of [`requirements-docker.lock`](https://github.com/Quansight/ragna/blob/main/requirements-docker.lock)